### PR TITLE
WL-3968: Show warning message if no email address or suggestions url

### DIFF
--- a/feedback/src/webapp/js/feedback.js
+++ b/feedback/src/webapp/js/feedback.js
@@ -58,7 +58,7 @@
                                                     showHelpPanel : feedback.showHelpPanel,
                                                     showTechnicalPanel : feedback.showTechnicalPanel,
                                                     showSuggestionsPanel : feedback.showSuggestionsPanel,
-                                                    technicalToAddress : feedback.technicalToAddress}, 'feedback-content');
+                                                    technicalToAddress : feedback.technicalToAddress,
                                                     enableTechnical : feedback.enableTechnical}, 'feedback-content');
 
             $(document).ready(function () {


### PR DESCRIPTION
This was causing the Contact Us tool not to display  at all
