### PR TITLE
WL-1409 Better OpenURL support in citations

### DIFF
--- a/citations/citations-tool/tool/src/java/org/sakaiproject/citation/tool/CitationHelperAction.java
+++ b/citations/citations-tool/tool/src/java/org/sakaiproject/citation/tool/CitationHelperAction.java
@@ -2622,6 +2622,16 @@ public class CitationHelperAction extends VelocityPortletPaneledAction
 		if( getConfigurationService().librarySearchEnabled() ) {
 			context.put( "searchLibrary", Boolean.TRUE );
 		}
+
+		if (getConfigurationService().isExternalSerarchEnabled())
+		{
+			// External Library Search
+			context.put("externalSearch", Boolean.TRUE);
+			context.put("externalSearchUrl", getConfigurationService().getExternalSearchUrl());
+
+			String windowName = getSearchManager().getExternalSearchWindowName(contentService.getUuid(resourceId));
+			context.put("externalSearchWindowName", windowName);
+		}
 		
 		if(citationCollection == null || (citationCollection.size() <= 0 && unnestedCitationCollection.size()<=0) && nestedCollection.getChildren().size()<=0) {
 			


### PR DESCRIPTION
This code being missing (which basically puts some stuff in the context) was causing the Search Library button not to appear.
