### PR TITLE
WL-1011 Show Group names instead of IDs.

### DIFF
--- a/site-manage/site-manage-group-section-role-helper/tool/src/java/org/sakaiproject/site/tool/helper/managegroupsectionrole/impl/SiteManageGroupSectionRoleHandler.java
+++ b/site-manage/site-manage-group-section-role-helper/tool/src/java/org/sakaiproject/site/tool/helper/managegroupsectionrole/impl/SiteManageGroupSectionRoleHandler.java
@@ -340,21 +340,18 @@ public class SiteManageGroupSectionRoleHandler {
         String label = rosterID;
         try
         {
-            if (cms != null)
-            {
-                Section s = cms.getSection(rosterID);
-                if (s != null) {
-                    label = StringUtils.defaultIfBlank(s.getTitle(), rosterID);
-                }
-            }
-            if (groupProvider instanceof DisplayGroupProvider)
-            {
-                label = ((DisplayGroupProvider)groupProvider).getGroupName(rosterID);
+            Section s = cms.getSection(rosterID);
+            if (s != null) {
+                label = StringUtils.defaultIfBlank(s.getTitle(), rosterID);
             }
         }
         catch( IdNotFoundException ex )
         {
-            M_log.debug( this + ".getRosterLabel: no section found for " + rosterID, ex );
+            M_log.debug(this + ".getRosterLabel: no section found for " + rosterID, ex);
+            if (groupProvider instanceof DisplayGroupProvider)
+            {
+                label = ((DisplayGroupProvider)groupProvider).getGroupName(rosterID);
+            }
         }
 
         return label;


### PR DESCRIPTION
The CourseManagementService is always available and it was throwing an exception because it didn’t know about our group. Now when the exception is throw we fall back to the group provider.
