### PR TITLE
WL-837 Enable the Oxford Additional Access

### DIFF
--- a/docker/sakai/placeholder.properties
+++ b/docker/sakai/placeholder.properties
@@ -449,6 +449,21 @@ sitemanage.add.expand.template=true
 # WL-837 Allow .anon/.auth from site-manage.
 sitemanage.grant.anon=true
 sitemanage.grant.auth=false
+sitemanage.grant.uk.ac.ox.bod.allstaff=true
+sitemanage.grant.uk.ac.ox.bod.allusers=true
+sitemanage.grant.uk.ac.ox.bod.allstudents=true
+sitemanage.grant.uk.ac.ox.card.staff=true
+sitemanage.grant.uk.ac.ox.card.college=true
+sitemanage.grant.uk.ac.ox.card.dept=true
+sitemanage.grant.uk.ac.ox.card.ret=true
+sitemanage.grant.uk.ac.ox.card.senmem=true
+sitemanage.grant.uk.ac.ox.card.undergrad=true
+sitemanage.grant.uk.ac.ox.card.postgrad=true
+sitemanage.grant.uk.ac.ox.card.student=true
+sitemanage.grant.uk.ac.ox.card.cardholder=true
+sitemanage.grant.uk.ac.ox.card.virtual=true
+sitemanage.grant.uk.ac.ox.card.visitor=true
+
 
 # WL-891 Allow people update the permissions on the signup tool.
 signup.permission.update.enabled=true

--- a/providers/jldap/src/resources/UserAttributeRoleProvider_en_GB.properties
+++ b/providers/jldap/src/resources/UserAttributeRoleProvider_en_GB.properties
@@ -1,8 +1,10 @@
 # Same groups as Bodington
+.uk.ac.ox.bod=Oxford
 .uk.ac.ox.bod.allstaff=All Oxford Staff
 .uk.ac.ox.bod.allusers=All Oxford Users
 .uk.ac.ox.bod.allstudents=All Oxford Students
 
+.uk.ac.ox.card=Oxford Card Statuses
 # Groups based on OUCS card status
 .uk.ac.ox.card.staff=University Staff
 .uk.ac.ox.card.college=College Staff


### PR DESCRIPTION
In Sakai 11 you need to explicitly enable each of these groups in site info. Also the labels weren’t defined in our properties file which meant that the Site Info page wasn’t displaying nice descriptions of the groupings.
