### PR TITLE
WL-4455 Failure to display hierarchy of sites.

### DIFF
--- a/portal/portal-api/api/src/java/org/sakaiproject/portal/api/Neighbour.java
+++ b/portal/portal-api/api/src/java/org/sakaiproject/portal/api/Neighbour.java
@@ -19,8 +19,16 @@ public interface Neighbour {
      * A redirect that should be shown to the user.
      */
     interface Redirect {
+        /**
+         * The ID of the redirect.
+         * @return Cannot be <code>null</code>.
+         */
         String getId();
 
+        /**
+         * The title of the redirect.
+         * @return Cannot be <code>null</code>.
+         */
         String getTitle();
 
     }

--- a/tetraelf-hierarchy/hierarchy-api/api/src/java/org/sakaiproject/hierarchy/api/model/PortalNode.java
+++ b/tetraelf-hierarchy/hierarchy-api/api/src/java/org/sakaiproject/hierarchy/api/model/PortalNode.java
@@ -35,7 +35,7 @@ public interface PortalNode {
 	
 	/**
 	 * The title of this node that is displayed to the end user.
-	 * @return A String title. This may be <code>null</code>.
+	 * @return A String title. This may be <code>null</code> for example when this is a hidden redirect.
 	 */
 	public String getTitle();
 	

--- a/tetraelf-hierarchy/hierarchy-portal/impl/src/java/org/sakaiproject/portal/impl/RedirectNeighbour.java
+++ b/tetraelf-hierarchy/hierarchy-portal/impl/src/java/org/sakaiproject/portal/impl/RedirectNeighbour.java
@@ -33,7 +33,12 @@ public class RedirectNeighbour implements Neighbour {
 
             @Override
             public String getTitle() {
-                return redirect.getTitle();
+                // Hidden redirects don't have titles.
+                if (redirect.getTitle() == null) {
+                    return redirect.getName();
+                } else {
+                    return redirect.getTitle();
+                }
             }
         });
     }


### PR DESCRIPTION
When there is a hidden redirect the portal would throw an exception because there wasn’t a title on the redirect, now we cope with this by falling back to the name of the redirect in that case.

WL-7
