### PR TITLE
WL-4469 Don’t include <body in actual HTML files.

### DIFF
--- a/course-signup/tool/src/main/webapp/static/index.jsp
+++ b/course-signup/tool/src/main/webapp/static/index.jsp
@@ -160,10 +160,8 @@
 							"url": signupSiteId + "/html/" + id + ".html",
 							"cache": false,
 							"success": function(data){
-								// This is because we now top and tail files in Sakai.
-								data = data.replace(/^(.|\n)*<body[^>]*>/im, "");
-								data = data.replace(/<\/body[^>]*>(.|\n)*$/im, "");
-								$("#details").html(data);
+								var body = Text.extractBody(data);
+								$("#details").html(body);
 							}
 						});
 					};

--- a/course-signup/tool/src/main/webapp/static/lib/Text.js
+++ b/course-signup/tool/src/main/webapp/static/lib/Text.js
@@ -53,6 +53,19 @@ var Text = (function() {
 		 */
 		"isEmail": function(email) {
 		    return emailRegex.test(email);
+		},
+
+		/**
+		 * Extract HTML body.
+		 * @param html A string representing a HTML document.
+		 * @return Just the contents of the body.
+		 */
+		"extractBody": function (html) {
+			// This is because we now top and tail files in Sakai.
+			var body = html;
+			body = body.replace(/^(.|\n)*<body[^>]*>/im, "");
+			body = body.replace(/<\/body[^>]*>(.|\n)*$/im, "");
+			return body;
 		}
 	};
 })();

--- a/course-signup/tool/src/main/webapp/static/my.jsp
+++ b/course-signup/tool/src/main/webapp/static/my.jsp
@@ -77,9 +77,8 @@
 			"cache" : false,
 			"success" : function(data) {
 				// This is because we now top and tail files in Sakai.
-				data = data.replace(/^(.|\n)*<body[^>]*>/im, "");
-				data = data.replace(/<\/body[^>]*>(.|\n)*$/im, "");
-				$("#notes").html(data);
+				var body = Text.extractBody(data);
+				$("#notes").html(body);
 			}
 		});
 


### PR DESCRIPTION
This was breaking the portal’s rather simple detection of head/body. So we simply moved it out into a support JS files which doesn’t get filtered.
