### PR TITLE
WL-2779 - When a template is used to create a site, the given Icon URL is missing

### DIFF
--- a/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
+++ b/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
@@ -10522,7 +10522,7 @@ private Map<String,List> getTools(SessionState state, String type, Site site) {
 	private String transferSiteResource(String oSiteId, String nSiteId, String siteAttribute) {
 
 		SecurityService.pushAdvisor(SECURITY_ADVISOR_ALLOW_ALL);
-		String rv = "";
+		String rv = siteAttribute;
 
 		try {
 


### PR DESCRIPTION
When a template is used to create a site, the given Icon URL is missing
and thus the site icon is not displayed
