### PR TITLE
Fix for versions when building against clean repo.

### DIFF
--- a/course-signup/tool/pom.xml
+++ b/course-signup/tool/pom.xml
@@ -172,7 +172,7 @@
 		 <dependency>
 			<groupId>org.sakaiproject.oauth</groupId>
 			<artifactId>oauth-api</artifactId>
-			<version>1.1-SNAPSHOT</version>
+			<version>1.2-SNAPSHOT</version>
 			 <scope>provided</scope>
 		</dependency>
 

--- a/master/pom.xml
+++ b/master/pom.xml
@@ -134,7 +134,7 @@
     <sakai.jdk.version>1.8</sakai.jdk.version>
     <sakai.build.directory>target</sakai.build.directory>
     <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
-    <mneme.version>2.1.29</mneme.version>
+    <mneme.version>2.1.37-SNAPSHOT</mneme.version>
   </properties>
   <distributionManagement>
     <snapshotRepository>


### PR DESCRIPTION
We were depending on some SNAPSHOT artifacts that weren’t being built as part of our standard full build. This was puling in some 10-SNAPSHOT artifacts into our build. It was also causing the build to fail if you had a clean maven repository.
