### PR TITLE
WL-4542 Switch to VARCHAR rather than INTs for enum.

### DIFF
--- a/oauth/dao-hbm/src/resources/org/sakaiproject/oauth/dao/Accessor.hbm.xml
+++ b/oauth/dao-hbm/src/resources/org/sakaiproject/oauth/dao/Accessor.hbm.xml
@@ -37,11 +37,13 @@
         <property name="status">
             <type name="org.hibernate.type.EnumType">
                 <param name="enumClass">org.sakaiproject.oauth.domain.Accessor$Status</param>
+                <param name="type">12</param><!-- Make it a string -->
             </type>
         </property>
         <property name="type">
             <type name="org.hibernate.type.EnumType">
                 <param name="enumClass">org.sakaiproject.oauth.domain.Accessor$Type</param>
+                <param name="type">12</param><!-- Make it a string -->
             </type>
         </property>
         <property name="accessorSecret"/>


### PR DESCRIPTION
This makes the oauth code use VARCHARs rather than INTs for it’s enums as it makes the database more readable and helps to prevent problems when enums are changed.

This is also needed as we currently have this setup from our 10.x OAuth deployment and migrating to INTs seems like a backwards step.
