### PR TITLE
WL-4530 Ignore trailing colons in site id aliases.

### DIFF
--- a/tetraelf-hierarchy/hierarchy-portal/pack/src/webapp/WEB-INF/components.xml
+++ b/tetraelf-hierarchy/hierarchy-portal/pack/src/webapp/WEB-INF/components.xml
@@ -13,6 +13,9 @@
 			<ref
 				bean="org.sakaiproject.hierarchy.api.PortalHierarchyService" />
 		</property>
+		<property name="serverConfigurationService">
+			<ref bean="org.sakaiproject.component.api.ServerConfigurationService"/>
+		</property>
 	</bean>
 	
 	<bean id="org.sakaiproject.portal.impl.HierarchySiteAliasProvider"


### PR DESCRIPTION
We just redirect away to the correct URL, this is better than supporting them in the lookups as it means people don’t start using these bad URLs as bookmarks and links in pages.
