### PR TITLE
WL-4568 Correctly save a messages posting.

### DIFF
--- a/msgcntr/messageforums-component-impl/src/java/org/sakaiproject/component/app/messageforums/MessageForumsMessageManagerImpl.java
+++ b/msgcntr/messageforums-component-impl/src/java/org/sakaiproject/component/app/messageforums/MessageForumsMessageManagerImpl.java
@@ -1381,13 +1381,16 @@ public class MessageForumsMessageManagerImpl extends HibernateDaoSupport impleme
         }
 
         boolean markupFree = false;
-        BaseForum forum = message.getTopic().getBaseForum();
-        if (forum instanceof DiscussionForum) {
-            DiscussionForum dForum = (DiscussionForum)forum;
-            markupFree = dForum.getMarkupFree();
-        }
-        if (markupFree) {
-            message.setBody(messageParsingService.parse(message.getBody()));
+        Topic topic = message.getTopic();
+        if (topic != null) {
+            BaseForum forum = topic.getBaseForum();
+            if (forum instanceof DiscussionForum) {
+                DiscussionForum dForum = (DiscussionForum) forum;
+                markupFree = dForum.getMarkupFree();
+            }
+            if (markupFree) {
+                message.setBody(messageParsingService.parse(message.getBody()));
+            }
         }
         message.setModified(new Date());
         if(getCurrentUser()!=null){


### PR DESCRIPTION
When sending using the messages tool there isn’t a topic available so it was failing with a NPE, now we check to see that we have a topic before attempting to find out if it’s part of a plain text forum.

Original work: WL-4466
