### PR TITLE
WL-496 Hide unpublished site in hierarchy.

### DIFF
--- a/portal/portal-api/api/src/java/org/sakaiproject/portal/api/Neighbour.java
+++ b/portal/portal-api/api/src/java/org/sakaiproject/portal/api/Neighbour.java
@@ -31,6 +31,13 @@ public interface Neighbour {
          */
         String getTitle();
 
+        /**
+         * Should this redirect be shown  to users. A hidden redirect still works for users they just
+         * don't know it exists until they access it.
+         * @return <code>true</code> if users shouldn't see the redirect.
+         */
+        boolean isHidden();
+
     }
 
 }

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/site/SubSiteViewImpl.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/site/SubSiteViewImpl.java
@@ -110,6 +110,7 @@ public class SubSiteViewImpl extends AbstractSiteViewImpl
 		if (prefix != null) siteUrlPrefix = siteUrlPrefix + prefix + "/";
 		map.put("url", siteUrlPrefix + siteHelper.getSiteEffectiveId(site));
 		map.put("iconClass", "icon-sakai-sub-site");
+		map.put("hidden", !site.isPublished());
 		return map;
 	}
 
@@ -122,6 +123,7 @@ public class SubSiteViewImpl extends AbstractSiteViewImpl
 		if (prefix != null) siteUrlPrefix = siteUrlPrefix + prefix + "/";
 		map.put("url", siteUrlPrefix + (redirect.getId() ));
 		map.put("iconClass", "icon-sakai-redirect");
+		map.put("hidden", redirect.isHidden());
 		return map;
 	}
 

--- a/portal/portal-render-engine-impl/pack/src/webapp/vm/morpheus/includePageNav.vm
+++ b/portal/portal-render-engine-impl/pack/src/webapp/vm/morpheus/includePageNav.vm
@@ -189,7 +189,7 @@
                     #foreach ( $site in $subSites.children )
 
                         <li>
-                            <a class="Mrphs-toolsNav__menuitem--link #if(!${site.isPublished})is-invisible#end" href="${site.url}" title="${site.title}" role="menuitem">
+                            <a class="Mrphs-toolsNav__menuitem--link #if(${site.hidden})is-invisible#end" href="${site.url}" title="${site.title}" role="menuitem">
 								<span class="Mrphs-toolsNav__menuitem--icon ${site.iconClass}"></span>
                                 <span class="Mrphs-toolsNav__menuitem--title">${site.titleTruncated}</span>
                             </a>

--- a/tetraelf-hierarchy/hierarchy-portal/impl/src/java/org/sakaiproject/portal/impl/RedirectNeighbour.java
+++ b/tetraelf-hierarchy/hierarchy-portal/impl/src/java/org/sakaiproject/portal/impl/RedirectNeighbour.java
@@ -40,6 +40,11 @@ public class RedirectNeighbour implements Neighbour {
                     return redirect.getTitle();
                 }
             }
+
+            @Override
+            public boolean isHidden() {
+                return redirect.isHidden();
+            }
         });
     }
 }


### PR DESCRIPTION
This also hides redirects that shouldn’t be shown.
