### PR TITLE
WL-4557: Tools & Subsites menu obscured when not logged in (Mobile view)

### DIFF
--- a/reference/library/src/morpheus-master/sass/modules/navigation/_base.scss
+++ b/reference/library/src/morpheus-master/sass/modules/navigation/_base.scss
@@ -401,6 +401,9 @@ body.is-logged-out{
 
 	.#{$namespace}loginUser{
 		padding: 0.9em 0.5em;
+		@media #{$phone}{
+			padding: 0em;
+		}
 	}
 
 	.#{$namespace}userNav__dropdown, .#{$namespace}userNav__drop{


### PR DESCRIPTION
The Jira does say to show more of the 'Tools and Subsites' menu on a phone by changing the link text as it's a quick fix but I 've done it in the css for two reasons: 1.  It's actually not that quick as you'd need to add 2 new properties probably and change the code to choose them if it's a phone. 2.  The css seems like the better place to do this as it is a styling issue after all.   
