### PR TITLE
WL-4539 Don’t fail elfinder when can’t access site.

### DIFF
--- a/textarea/elfinder-sakai/src/java/org/sakaiproject/elfinder/sakai/SakaiFsService.java
+++ b/textarea/elfinder-sakai/src/java/org/sakaiproject/elfinder/sakai/SakaiFsService.java
@@ -179,7 +179,10 @@ public class SakaiFsService implements FsService {
 			if("!admin".equals(currentSiteId) || "~admin".equals(currentSiteId)){
 				continue;
 			}
-			volumes.add(getSiteVolume(currentSiteId));
+			// Only add sites user can access.
+			if (siteService.allowAccessSite(currentSiteId)) {
+				volumes.add(getSiteVolume(currentSiteId));
+			}
 		}
 		return volumes.toArray(new FsVolume[0]);
 	}

--- a/textarea/elfinder-sakai/src/java/org/sakaiproject/elfinder/sakai/site/SiteFsVolume.java
+++ b/textarea/elfinder-sakai/src/java/org/sakaiproject/elfinder/sakai/site/SiteFsVolume.java
@@ -1,6 +1,8 @@
 package org.sakaiproject.elfinder.sakai.site;
 
 import cn.bluejoe.elfinder.service.FsItem;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.sakaiproject.component.cover.ComponentManager;
 import org.sakaiproject.elfinder.sakai.SiteVolumeFactory;
 import org.sakaiproject.elfinder.sakai.ReadOnlyFsVolume;
@@ -23,6 +25,8 @@ import java.util.Map;
  *
  */
 public class SiteFsVolume extends ReadOnlyFsVolume {
+
+    private final static Log log = LogFactory.getLog(SiteFsVolume.class);
 
     public String getSiteId() {
         return siteId;
@@ -134,9 +138,9 @@ public class SiteFsVolume extends ReadOnlyFsVolume {
                 }
             }
         } catch (PermissionException pe) {
-            throw new IllegalArgumentException("The current user doesn't have access to: "+ siteId);
+            log.debug("The current user doesn't have access to: "+ siteId);
         } catch (IdUnusedException iue) {
-            throw new IllegalArgumentException("There is no site with ID: "+ siteId);
+            log.debug("There is no site with ID: "+ siteId);
         }
         return children.toArray(new FsItem[0]);
     }


### PR DESCRIPTION
We have secure sites which you can only access once you are 2 factor authenticated and so failing the whole connector request if one of the sites the user is a member of isn’t accessible is wrong. This is a 2 part fix, firstly we filter out the sites that can’t currently be accessed, secondly if someone does attempt to access one we just show it as empty.
