### PR TITLE
WL-4572 Fix for typo introduced in the Morpheus update.

### DIFF
--- a/evaluations/tool/src/webapp/component-templates/new_date_field_input.html
+++ b/evaluations/tool/src/webapp/component-templates/new_date_field_input.html
@@ -4,7 +4,7 @@
 <head>
     <!-- These need to be pulled in all the time and the rsf:id does this. -->
     <script type="text/javascript" src="/library/webjars/jquery/1.11.3/jquery.min.js" rsf:id="scr=contribute-script"></script>
-    <script type="text/javascript" src="/library/webjars/jquery-ui/1.11.3/jquery-ui.min.css" rsf:id="scr=contribute-script"></script>
+    <script type="text/javascript" src="/library/webjars/jquery-ui/1.11.3/jquery-ui.min.js" rsf:id="scr=contribute-script"></script>
     <link href="/library/webjars/jquery-ui/1.11.3/jquery-ui.min.css" rel="stylesheet" type="text/css" rsf:id="scr=contribute-style" />
     <script type="text/javascript" src="/library/js/lang-datepicker/lang-datepicker.js" rsf:id="scr=contribute-script"></script>
     <script type="text/javascript" rsf:id="scr=contribute-script">


### PR DESCRIPTION
This gets the date picker working again when creating an evaluation survey.
