### PR TITLE
WL-3328 rWiki pops up a warning about missing jsMaths library over an…

### DIFF
--- a/reference/library/pom.xml
+++ b/reference/library/pom.xml
@@ -144,7 +144,7 @@
 		<profile>
 			<id>with-jsmath</id>
 			<activation>
-				<activeByDefault>false</activeByDefault>
+				<activeByDefault>true</activeByDefault>
 				<property>
 					<name>sakai.withjsmath</name>
 					<value>true</value>


### PR DESCRIPTION
…d over

Previous fix for the jira got overridden so did it again.
