### PR TITLE
WL-4578 Don’t log a warning when no announcement tool.

### DIFF
--- a/announcement/announcement-tool/tool/src/java/org/sakaiproject/announcement/tool/AnnouncementAction.java
+++ b/announcement/announcement-tool/tool/src/java/org/sakaiproject/announcement/tool/AnnouncementAction.java
@@ -1553,18 +1553,20 @@ public class AnnouncementAction extends PagedResourceActionII
 							Site siteDD = null;
 
 							try {
-								AnnouncementChannel annChannell= AnnouncementService.getAnnouncementChannel(channeIDD);
-								if (annChannell != null ) {	
+								AnnouncementChannel annChannell = AnnouncementService.getAnnouncementChannel(channeIDD);
+								if (annChannell != null) {
 									contextt = annChannell.getContext();
 								}
-								if (contextt != null) { 
+								if (contextt != null) {
 									siteDD = SiteService.getSite(contextt);
 								}
-								if ( siteDD!=null && siteDD.isPublished()) {
+								if (siteDD != null && siteDD.isPublished()) {
 									channelIdStrArray.add(channeIDD);
 								}
+							} catch (IdUnusedException iue) {
+								M_log.debug("Channel doesn't exist: "+ channeIDD, iue);
 							} catch(Exception e) {
-								M_log.warn(e.getMessage());
+								M_log.warn("Failed to load channel: "+channeIDD, e);
 							}
 						}
 						if (channelIdStrArray.size()>0) {


### PR DESCRIPTION
If a site that a user is a member of doesn’t have an announcements tool an empty message is logged.
