### PR TITLE
WL-3639 Fix sentry for Sakai 11.

### DIFF
--- a/deploy/common/pom.xml
+++ b/deploy/common/pom.xml
@@ -25,5 +25,11 @@
         <deploy.target>common</deploy.target>
     </properties>
 
-    <dependencies />
+    <dependencies>
+        <dependency>
+            <groupId>org.sakaiproject.sentry</groupId>
+            <artifactId>raven-sakai</artifactId>
+            <version>1.1</version>
+        </dependency>
+    </dependencies>
 </project>

--- a/docker/sakai/docker-compose.yml
+++ b/docker/sakai/docker-compose.yml
@@ -27,6 +27,7 @@ app:
   environment:
    # In development this means we can read files without anything special
    SAKAI_USER: root
+   SENTRY_DSN:
   links:
    - db
    - solr

--- a/docker/sakai/log4j.properties
+++ b/docker/sakai/log4j.properties
@@ -1,7 +1,20 @@
-log4j.rootLogger=WARN, console, catalina
+log4j.rootLogger=WARN, console, sentry, catalina
+
+# Sentry setup
+# The DSN should be supplied through the envrionment
+log4j.appender.sentry=net.kencochrane.raven.log4j.SentryAppender
+# This is so that we get the correct hostname in docker
+log4j.appender.sentry.ravenFactory=org.sakaiproject.sentry.DockerRavenFactory
+log4j.appender.sentry.Threshold=ERROR
 
 log4j.logger.org.apache.pdfbox.pdmodel.font.PDCIDFont=OFF
 log4j.logger.org.apache.fop.datatypes.LengthBase=OFF
+log4j.logger.net.kencochrane.raven.RavenFactory=DEBUG
+
+# Only send the solr re-index errors to the console as they perform a
+# denial of service attack on sentry, taking it down.
+log4j.logger.org.sakaiproject.search.queueing.WaitingTaskRunner=WARN,console
+log4j.additivity.org.sakaiproject.search.queueing.WaitingTaskRunner=false
 
 # Console setup
 log4j.appender.console=org.apache.log4j.ConsoleAppender
@@ -25,9 +38,20 @@ log4j.logger.org.sakaiproject=INFO
 log4j.logger.uk.ac.cam.caret.rwiki=INFO
 log4j.logger.org.theospi=INFO
 log4j.logger.MySQL=INFO
+log4j.logger.uk.ac.ox.oucs=INFO
+log4j.logger.net.sf.snmpadaptor4j=INFO
 
 # Ignore erroneous MyFaces warnings
 log4j.logger.org.apache.myfaces=ERROR
+
+#log4j.appender.deleted=org.apache.log4j.net.SyslogAppender
+#log4j.appender.deleted.SyslogHost=localhost
+#log4j.appender.deleted.Facility=local1
+#log4j.appender.deleted.layout=org.apache.log4j.PatternLayout
+#log4j.appender.deleted.layout.ConversionPattern= %d{ISO8601} %5p %t %c - %m%n
+
+#log4j.logger.org.sakaiproject.site.impl.SiteRemovalLogger=INFO, deleted
+#log4j.additivity.org.sakaiproject.site.impl.SiteRemovalLogger=false
 
 # Setup vm levels
 log4j.logger.vm.none=FATAL
@@ -36,3 +60,5 @@ log4j.logger.vm.warn=WARN
 log4j.logger.vm.info=INFO
 log4j.logger.vm.debug=DEBUG
 
+# This is so that we can tell when LDAP servers get gracefuly shutdown
+log4j.logger.edu.amc.sakai.user.NativeLdapConnectionLivenessValidator=DEBUG


### PR DESCRIPTION
The sentry appender wasn’t included in the build and the log4j config was missing. This should help us catch any errors on go-live as sentry makes it much easier to spot where stuff is happening.

Also includes some other log4j config changes that got lost.
