### PR TITLE
WL-4580 Don’t use admin realm when role swap active.

### DIFF
--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/authz/impl/DevolvedSakaiSecurityImpl.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/authz/impl/DevolvedSakaiSecurityImpl.java
@@ -274,15 +274,20 @@ public abstract class DevolvedSakaiSecurityImpl extends SakaiSecurity implements
 		}
 
 		Collection<String> expandedAzgs = new HashSet<>();
-		for (String azg: azgs) {
-			String adminRealm = getAdminRealm(azg);
-			if (adminRealm != null) {
-				if (log.isDebugEnabled()) {
-					log.debug("Adding admin realm: " + adminRealm + " for: " + azg);
+		if (roleswap == null ) {
+			// We only want to add the admin realms when not in roleswap
+			for (String azg : azgs) {
+				String adminRealm = getAdminRealm(azg);
+				if (adminRealm != null) {
+					if (log.isDebugEnabled()) {
+						log.debug("Adding admin realm: " + adminRealm + " for: " + azg);
+					}
+					expandedAzgs.add(adminRealm);
 				}
-				expandedAzgs.add(adminRealm);
+				expandedAzgs.add(azg);
 			}
-			expandedAzgs.add(azg);
+		} else {
+			expandedAzgs = azgs;
 		}
 		// check the cache
 		String command = makeCacheKey(userId, roleswap, function, entityRef, false);


### PR DESCRIPTION
If the user has swapped roles in the current site don’t use the admin site as well as this defeats the purpose of swapping roles.
