### PR TITLE
WL-3003 Only show hidden redirects to maintainers

### DIFF
--- a/tetraelf-hierarchy/hierarchy-portal/impl/src/java/org/sakaiproject/portal/impl/HierarchySiteNeighbourhoodService.java
+++ b/tetraelf-hierarchy/hierarchy-portal/impl/src/java/org/sakaiproject/portal/impl/HierarchySiteNeighbourhoodService.java
@@ -69,6 +69,7 @@ public class HierarchySiteNeighbourhoodService implements SiteNeighbourhoodServi
 		if( nodeId != null) {
 			PortalNode node = portalHierarchyService.getNodeByUrl(nodeId);
 			if (node instanceof PortalNodeSite) {
+				boolean seeHiddenRedirects = node.canModify();
 				List<PortalNode> nodeChildren = portalHierarchyService.getNodeChildren(node.getId());
 				List<Neighbour> neighbours = new ArrayList<>();
 				for (PortalNode child: nodeChildren) {
@@ -83,7 +84,9 @@ public class HierarchySiteNeighbourhoodService implements SiteNeighbourhoodServi
 					}
 					if (child instanceof PortalNodeRedirect) {
 						PortalNodeRedirect redirect = (PortalNodeRedirect) child;
-						neighbours.add(new RedirectNeighbour(redirect));
+						if (seeHiddenRedirects || !redirect.isHidden()) {
+							neighbours.add(new RedirectNeighbour(redirect));
+						}
 					}
 
 				}


### PR DESCRIPTION
Redirects that are hidden should only be show to people who are a maintainer on the current node.
