### PR TITLE
WL-4545 Disable portal alias as they aren’t cached.

### DIFF
--- a/docker/sakai/placeholder.properties
+++ b/docker/sakai/placeholder.properties
@@ -241,9 +241,6 @@ portal.use.dhtml.more=true
 # Include stack traces in error reports.
 portal.error.showdetail=true
 
-# Generate nice aliases for all pages in a site.
-portal.use.page.aliases=true
-
 # Bug fix so that we get tabs when not logged in.
 gatewaySiteList=!gateway
 


### PR DESCRIPTION
They are also not needed as all the links are to tools now rather than pages.
We should in the future generate nice tool aliases but we’re not doing this for now.
