### PR TITLE
WL-4417: Members added via Participant groups not added to site

### DIFF
--- a/external-groups/tool/src/main/java/uk/ac/ox/oucs/vle/MappedGroupsResource.java
+++ b/external-groups/tool/src/main/java/uk/ac/ox/oucs/vle/MappedGroupsResource.java
@@ -19,6 +19,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.json.JSONArray;
 import org.json.JSONObject;
+import org.sakaiproject.authz.api.AuthzGroupService;
 import org.sakaiproject.authz.api.GroupProvider;
 import org.sakaiproject.site.api.Site;
 import org.sakaiproject.site.api.SiteService;
@@ -31,6 +32,7 @@ public class MappedGroupsResource {
 	private ExternalGroupManager externalGroupManager;
 	private GroupProvider groupProvider;
 	private SiteService siteService;
+	private AuthzGroupService authzGroupService;
 
 	public static final String SUSPENDED = "suspended";
 
@@ -38,6 +40,7 @@ public class MappedGroupsResource {
 		externalGroupManager = (ExternalGroupManager)resolver.getContext(ExternalGroupManager.class);
 		groupProvider = (GroupProvider)resolver.getContext(GroupProvider.class);
 		siteService = (SiteService)resolver.getContext(SiteService.class);
+		authzGroupService = (AuthzGroupService)resolver.getContext(AuthzGroupService.class);
 	}
 	
 
@@ -108,7 +111,8 @@ public class MappedGroupsResource {
 					log.debug("Set site : "+ site.getId()+ " provided id to: "+ providedId);
 				}
 				siteService.saveSiteMembership(site);
-				
+				authzGroupService.refreshAuthzGroupInternal(site);
+
 				return Response.ok().build();
 			} catch (Exception e) {
 				log.warn("Failed to add group.", e);

--- a/kernel/api/src/main/java/org/sakaiproject/authz/api/AuthzGroupService.java
+++ b/kernel/api/src/main/java/org/sakaiproject/authz/api/AuthzGroupService.java
@@ -29,6 +29,7 @@ import java.util.Set;
 
 import org.sakaiproject.entity.api.EntityProducer;
 import org.sakaiproject.javax.PagingPosition;
+import org.sakaiproject.site.api.Site;
 
 /**
  * <p>
@@ -543,4 +544,11 @@ public interface AuthzGroupService extends EntityProducer
      * @return String Set containing all maintain roles.
      */
     public Set<String> getMaintainRoles();
+
+    /**
+     * Update the realm with info from the provider
+     *
+     * @param realm the AuthzGroup to be refreshed
+     */
+    public void refreshAuthzGroupInternal(AuthzGroup realm);
 }

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/authz/impl/DbAuthzGroupService.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/authz/impl/DbAuthzGroupService.java
@@ -35,7 +35,9 @@ import org.sakaiproject.event.api.NotificationService;
 import org.sakaiproject.javax.PagingPosition;
 import org.sakaiproject.memory.api.Cache;
 import org.sakaiproject.memory.api.MemoryService;
+import org.sakaiproject.site.api.Site;
 import org.sakaiproject.site.api.SiteService;
+import org.sakaiproject.site.impl.BaseSite;
 import org.sakaiproject.time.api.Time;
 import org.sakaiproject.user.api.UserNotDefinedException;
 import org.sakaiproject.util.BaseDbFlatStorage;
@@ -657,6 +659,16 @@ public abstract class DbAuthzGroupService extends BaseAuthzGroupService implemen
 	        rv.put(userId, new MemberWithRoleId(member));
 	    }
 	    return rv;
+	}
+
+
+	@Override
+	public void refreshAuthzGroupInternal(AuthzGroup realm) {
+		try {
+			((DbStorage) m_storage).refreshAuthzGroupInternal(((BaseSite)realm).getAzg());
+		} catch (Throwable e) {
+			M_log.error("refreshAuthzGroupInternal() Problem refreshing azgroup: " + realm.getId(), e);
+		}
 	}
 
 	/**
@@ -2615,7 +2627,7 @@ public abstract class DbAuthzGroupService extends BaseAuthzGroupService implemen
 		 * 
 		 * @param realm the realm to be refreshed
 		 */
-		protected void refreshAuthzGroupInternal(BaseAuthzGroup realm)
+		protected void refreshAuthzGroupInternal(AuthzGroup realm)
 		{
 			if ((realm == null) || (m_provider == null)) return;
 			if (M_log.isDebugEnabled()) M_log.debug("refreshAuthzGroupInternal() refreshing " + realm.getId());

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/site/impl/BaseSite.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/site/impl/BaseSite.java
@@ -1743,7 +1743,7 @@ public class BaseSite implements Site
 	 * 
 	 * @return My azg.
 	 */
-	protected AuthzGroup getAzg()
+	public AuthzGroup getAzg()
 	{
 		if (m_azg == null)
 		{


### PR DESCRIPTION
When a participant group is added to a site in SiteInfo, the members will not show up on the next page until the 'RefreshAuthzGroupTask' thread has run (which refreshes updated site memberships in the db).  So when a group has been added, it may be 60 seconds (=the default) until this task runs.  

The simplest and cleanest fix here to get the added groups showing straight away is to run the single line of thread code that refreshes the memberships right after the group has been added in MappedGroupsResource.java.  To avoid any performance problems, the single line of code just does the update for the current site and group that's been added and not any queued updates. 
