### PR TITLE
Wl-411 Add missing mappings from Sakai 11 upgrade.

### DIFF
--- a/docker/sakai/placeholder.properties
+++ b/docker/sakai/placeholder.properties
@@ -92,7 +92,6 @@ login.container.logout.url=https://webauth.ox.ac.uk/logout
 
 # WL-411 Show errors on container auth failure.
 login.container.fallthrough=false
-login.container.fallthough=false
 
 # Allow login choice.
 login.auth.choice=true

--- a/login/login-tool/tool/src/webapp/WEB-INF/web.xml
+++ b/login/login-tool/tool/src/webapp/WEB-INF/web.xml
@@ -139,6 +139,16 @@
         <url-pattern>/twofactor/*</url-pattern>
     </servlet-mapping>
 
+    <servlet-mapping>
+        <servlet-name>exception.jsp</servlet-name>
+        <url-pattern>/exception.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>missing.jsp</servlet-name>
+        <url-pattern>/missing.jsp</url-pattern>
+    </servlet-mapping>
+
      <servlet-mapping>
          <servlet-name>sakai.login</servlet-name>
          <url-pattern>/*</url-pattern>


### PR DESCRIPTION
Also drop unused property that was part of the WL-411 and is no longer needed as it was originally a typo.
