### PR TITLE
WL-4148 Added email domain validator in profile tool.

### DIFF
--- a/profile2/bundle/src/resources/ProfileApplication.properties
+++ b/profile2/bundle/src/resources/ProfileApplication.properties
@@ -145,7 +145,10 @@ button.worksite.cancel            = Cancel
 button.worksite.create            = Create
 
 #EmailAddressValidator = '${input}' is not a valid email address. ##default
-email.EmailAddressValidator = Invalid email address
+email.EmailValidator.invalid = Invalid email address
+email.EmailValidator.profile.emailbaddomain = It has not been possible to update the email address for this account because you are not allowed to \
+supply an address containing ${invalidAccount} for this type of account.If you wish messages to be sent \
+to this address then you should login using your ${localAccount}.
 
 error.empty.file.uploaded           = You tried to upload an empty file
 error.file.save.failed              = Saving the file failed

--- a/profile2/tool/src/java/org/sakaiproject/profile2/tool/components/EmailValidator.java
+++ b/profile2/tool/src/java/org/sakaiproject/profile2/tool/components/EmailValidator.java
@@ -1,0 +1,43 @@
+package org.sakaiproject.profile2.tool.components;
+
+import org.apache.wicket.validation.IValidatable;
+import org.apache.wicket.validation.Validatable;
+import org.apache.wicket.validation.validator.AbstractValidator;
+import org.apache.wicket.validation.validator.EmailAddressValidator;
+import org.sakaiproject.component.cover.ServerConfigurationService;
+import org.sakaiproject.util.Validator;
+
+import java.util.Map;
+
+/**
+ * Validator for email address in profile
+ * uses Wicket's EmailAddressValidator for email format check and kernel's
+ * Validator to check if the email address is of local domain or not.
+ */
+public class EmailValidator extends AbstractValidator {
+	private static final long serialVersionUID = 1L;
+	private static final String OFFICIAL_USER_NAME = "Official Username";
+
+	public void onValidate(IValidatable validatable) {
+		String emailText = (String)validatable.getValue();
+		Map map = super.variablesMap(validatable);
+		//Check first if the email address is of correct format
+		if (isValidEmailAddress(emailText)) {
+			//check if email address contains any of accepted local/official hosts
+			if(!Validator.isAllowedLocalEmailDomain(emailText)) {
+				map.put("invalidAccount", ServerConfigurationService.getString("invalidNonOfficialAccountString"));
+				map.put("localAccount", ServerConfigurationService.getString("localUserAccount", OFFICIAL_USER_NAME));
+				error(validatable, getClass().getSimpleName() + ".profile.emailbaddomain", map);
+			}
+		} else {
+			error(validatable, getClass().getSimpleName() + ".invalid", map);
+		}
+	}
+
+	private boolean isValidEmailAddress(final String emailAddress) {
+		Validatable validatable = new Validatable(emailAddress);
+		EmailAddressValidator.getInstance().validate(validatable);
+		return validatable.isValid();
+	}
+
+}

--- a/profile2/tool/src/java/org/sakaiproject/profile2/tool/pages/panels/MyContactEdit.java
+++ b/profile2/tool/src/java/org/sakaiproject/profile2/tool/pages/panels/MyContactEdit.java
@@ -47,6 +47,7 @@ import org.sakaiproject.profile2.tool.components.ComponentVisualErrorBehaviour;
 import org.sakaiproject.profile2.tool.components.ErrorLevelsFeedbackMessageFilter;
 import org.sakaiproject.profile2.tool.components.FeedbackLabel;
 import org.sakaiproject.profile2.tool.components.PhoneNumberValidator;
+import org.sakaiproject.profile2.tool.components.EmailValidator;
 import org.sakaiproject.profile2.util.ProfileConstants;
 
 public class MyContactEdit extends Panel {
@@ -114,7 +115,7 @@ public class MyContactEdit extends Panel {
 		final TextField email = new TextField("email", new PropertyModel(userProfile, "email"));
 		email.setOutputMarkupId(true);
 		email.setMarkupId("emailinput");
-		email.add(EmailAddressValidator.getInstance());
+		email.add(new EmailValidator());
 		//readonly view
 		Label emailReadOnly = new Label("emailReadOnly", new PropertyModel(userProfile, "email"));
 		
@@ -279,7 +280,7 @@ public class MyContactEdit extends Panel {
 				//check which item didn't validate and update the class and feedback model for that component
 				if(!email.isValid()) {
 					email.add(new AttributeAppender("class", new Model<String>("invalid"), " "));
-					emailFeedback.setDefaultModel(new ResourceModel("EmailAddressValidator"));
+					emailFeedback.setDefaultModel(new ResourceModel("EmailValidator"));
 					target.add(email);
 					target.add(emailFeedback);
 				}

--- a/user/user-tool/tool/src/bundle/admin.properties
+++ b/user/user-tool/tool/src/bundle/admin.properties
@@ -24,8 +24,6 @@ useedi.emailbaddomain = It has not been possible to update the email address for
                         to this address then you should login using your {1}.
 
 official.user.name = Official Username
-
-official.user.name = Official Username
 useedi.email.exists = There is already an account with this email address.
 useedi.val.email = We recommend that you update your User ID to match your new email address. To do this please click on the link in the validation email which has been sent to {0}. If you do not wish to change your User ID then please ignore the email.
 #merged all duplicates- SAK-18304


### PR DESCRIPTION
Created new EmailValidator class for validating email in profile.It uses
Wicket's EmailAddressValidator to check the format of email and Kernel's
Validator class to check for the valid domain.

Removed duplicate 'official.user.name' from admin.properties in user tool.
