### PR TITLE
WL-4585 Don’t flush the cache when loading.

### DIFF
--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/site/impl/DbSiteService.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/site/impl/DbSiteService.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -1059,9 +1060,11 @@ public abstract class DbSiteService extends BaseSiteService
 			SqlReader reader = requireDescription ? fullSiteReader : lightSiteReader;
 			String order = getSitesOrder(sort);
 
-
 			// Account for limitations in the number of IN parameters we can use by batching
-			int remaining = siteIds.size();
+			// Load just the sites that weren't found in cache
+			List<String> siteIdsToLoad = siteMap.entrySet().stream().filter(e -> e.getValue() == null)
+					.map(Map.Entry::getKey).collect(Collectors.toList());
+			int remaining = siteIdsToLoad.size();
 			while (remaining > 0)
 			{
 				// We are using fixed sized buckets for IN clause parameters, up to the platform maximum number and filling
@@ -1070,8 +1073,8 @@ public abstract class DbSiteService extends BaseSiteService
 				// and does not affect results against a non-null column (as with IDs).
 
 				// Fill a bucket by passing the sublist from our current element to the end (remaining length)
-				int start = siteIds.size() - remaining;
-				Object[] values = getFilledBucket(siteIds.subList(start, start + remaining));
+				int start = siteIdsToLoad.size() - remaining;
+				Object[] values = getFilledBucket(siteIdsToLoad.subList(start, start + remaining));
 				int bucketSize = values.length;
 				String where = getWhereSiteIdIn(values);
 
@@ -1094,7 +1097,7 @@ public abstract class DbSiteService extends BaseSiteService
 				if (i.next() == null) i.remove();
 			}
 
-			return new ArrayList<Site>(siteMap.values());
+			return new ArrayList<>(siteMap.values());
 		}
 
 		/**


### PR DESCRIPTION
When searching for sites the cache of fully loaded sites is replaced with sites that are partially loaded. This is because we’re searching for all the sites in the DB and replacing the values in the cache with them.
