### PR TITLE
WL-4457 When returning to a site 'Overview' tool will be displayed.

### DIFF
--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/SkinnableCharonPortal.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/SkinnableCharonPortal.java
@@ -444,6 +444,11 @@ public class SkinnableCharonPortal extends HttpServlet implements Portal
 		SiteView siteView = siteHelper.getSitesView(SiteView.View.SUB_SITES_VIEW,req, session, siteId, nodeId);
 		if ( siteView.isEmpty() ) return;
 
+		// If auto-state-reset is turned on generate the "site-reset" url
+		if ("true".equalsIgnoreCase(ServerConfigurationService.getString(Portal.CONFIG_AUTO_RESET)))
+		{
+			prefix = prefix + "-reset";
+		}
 		siteView.setPrefix(prefix);
 		siteView.setToolContextPath(toolContextPath);
 		siteView.setResetTools(resetTools);

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/SiteResetHandler.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/SiteResetHandler.java
@@ -24,8 +24,11 @@ package org.sakaiproject.portal.charon.handlers;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.sakaiproject.entity.api.Reference;
+import org.sakaiproject.entity.cover.EntityManager;
 import org.sakaiproject.portal.api.Portal;
 import org.sakaiproject.portal.api.PortalHandlerException;
+import org.sakaiproject.portal.api.SiteNeighbourhoodService;
 import org.sakaiproject.tool.api.Session;
 import org.sakaiproject.util.Validator;
 import org.sakaiproject.util.Web;
@@ -64,6 +67,17 @@ public class SiteResetHandler extends BasePortalHandler
 				}
 				// Forget about the last page.
 				String siteId = parts[2];
+				//Check if lastPage attribute in session is present or not
+				if (session.getAttribute(Portal.ATTR_SITE_PAGE + siteId) == null)
+				{
+					//if not then look for alias of SiteId
+					String reference = portal.getSiteNeighbourhoodService().parseSiteAlias(siteId);
+					if (reference != null)
+					{
+						Reference ref = EntityManager.getInstance().newReference(reference);
+						siteId = ref.getId();
+					}
+				}
 				session.removeAttribute(Portal.ATTR_SITE_PAGE + siteId);
 				portalService.setResetState("true");
 				res.sendRedirect(siteUrl);


### PR DESCRIPTION
Added check in SiteResetHandler for aliases of siteId as hierarchy
sites have aliases. Added prefix 'reset' in SkinnableCharonPortal
for sites if the CONFIG_AUTO_RESET property is set in the config.
