### PR TITLE
WL-4556 subpage in lessons breadcrumb trail is white now.

### DIFF
--- a/lessonbuilder/tool/src/webapp/css/Simplepagetool.css
+++ b/lessonbuilder/tool/src/webapp/css/Simplepagetool.css
@@ -1057,6 +1057,7 @@ ul#toolbar li em {
 .lessons-siteHierarchy-title {
    font-weight: bold;
    margin-left: 0.5em;
+   color: #fff;
 }
 .itemAction {
   padding-top: 0px;


### PR DESCRIPTION
added colour white to lessons subpage class in SimplePageTool.css
