### PR TITLE
WL-4603 Subpage in lessons breadcrumb trail is in the same line.

### DIFF
--- a/lessonbuilder/tool/src/webapp/templates/ShowPage.html
+++ b/lessonbuilder/tool/src/webapp/templates/ShowPage.html
@@ -223,7 +223,7 @@
 	if (jQuery(".oldPortal").size() === 0) {
 	    var title = jQuery(".title span:last").text();
 	    if (breadcrumbs.size() > 0) {
-		jQuery(".Mrphs-siteHierarchy").append(jQuery(".breadcrumbs span").slice(1));
+		jQuery(".Mrphs-siteHierarchyAlign").append(jQuery(".breadcrumbs span").slice(1));
 	    }
 	    jQuery(".Mrphs-siteHierarchy").children().wrapAll('<div class="hierarchyWrap" />');
 	    jQuery(".Mrphs-siteHierarchy").append(jQuery("span.nextprev"));


### PR DESCRIPTION
New div with class name'Mrphs-siteHierarchyAlign' is added in WL
in Navigation tab therefore in Lessons 'ShowPage.html' breadcrumb
should be appended after the new div instead of
'Mrphs-siteHierarchy' div.
