### PR TITLE
WL-4610 Hide only top prev and next buttons not the bottom ones.

### DIFF
--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/beans/SimplePageBean.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/beans/SimplePageBean.java
@@ -170,6 +170,9 @@ public class SimplePageBean {
 
 	private String filterHtml = ServerConfigurationService.getString(FILTERHTML);
 
+	//Check in the property file if top prev and next buttons are suppressed
+	private boolean disableTopPrevNextLink = ServerConfigurationService.getBoolean("lessons.surpress.top.prevAndNextButtons",false);
+
 	public String selectedAssignment = null;
 	public String selectedBlti = null;
 
@@ -1898,7 +1901,10 @@ public class SimplePageBean {
 				view.setSendingPage(e.pageId);
 				view.setItemId(e.pageItemId);
 				view.setPath(Integer.toString(top));
-				UIInternalLink.make(tofill, "next", messageLocator.getMessage("simplepage.next"), view);
+				//if top next button is suppressed, hide it
+				if(!disableTopPrevNextLink){
+					UIInternalLink.make(tofill, "next", messageLocator.getMessage("simplepage.next"), view);
+				}
 				UIInternalLink.make(tofill, "next1", messageLocator.getMessage("simplepage.next"), view);
 			}
 	    } else  if (nextItem != null) {
@@ -1952,7 +1958,10 @@ public class SimplePageBean {
 	    	
 	    	view.setItemId(nextItem.getId());
 	    	view.setBackPath("push");
-	    	UIInternalLink.make(tofill, "next", messageLocator.getMessage("simplepage.next"), view);
+	    	//if top next button is suppressed , hide it
+	    	if(!disableTopPrevNextLink){
+	    		UIInternalLink.make(tofill, "next", messageLocator.getMessage("simplepage.next"), view);
+	    	}
 	    	UIInternalLink.make(tofill, "next1", messageLocator.getMessage("simplepage.next"), view);
 	    }
 	}
@@ -2035,7 +2044,10 @@ public class SimplePageBean {
 		}
 		view.setItemId(prevItem.getId());
 		view.setBackPath("pop");
-		UIInternalLink.make(tofill, "prev", messageLocator.getMessage("simplepage.back"), view);
+		//if top prev button is suppressed, hide it
+		if(!disableTopPrevNextLink){
+			UIInternalLink.make(tofill, "prev", messageLocator.getMessage("simplepage.back"), view);
+		}
 		UIInternalLink.make(tofill, "prev1", messageLocator.getMessage("simplepage.back"), view);
 	}
 

--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/producers/ShowPageProducer.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/producers/ShowPageProducer.java
@@ -1059,14 +1059,9 @@ public class ShowPageProducer implements ViewComponentProducer, DefaultView, Nav
 		    }
 		}
 
-		//Check in the property file if prev and next buttons are suppressed
-		boolean disablePrevNextLink = ServerConfigurationService.getBoolean("lessons.surpress.top.prevAndNextButtons",false);
-		if(!disablePrevNextLink){
-			// see if there's a next item in sequence.
-			simplePageBean.addPrevLink(tofill, pageItem);
-			simplePageBean.addNextLink(tofill, pageItem);
-		}
-
+		// see if there's a next item in sequence.
+		simplePageBean.addPrevLink(tofill, pageItem);
+		simplePageBean.addNextLink(tofill, pageItem);
 
 		// swfObject is not currently used
 		boolean shownSwfObject = false;


### PR DESCRIPTION
Added check in the SimplePageBean class to hide only the top 'Next' and
'Prev' buttons. Removed previous fix from the ShowPageProducer class which
was hiding both the top and bottom Next and Prev buttons.
