### PR TITLE
WL-4546: The search in the 'Sites' pop-up doesn't work properly

### DIFF
--- a/portal/portal-render-engine-impl/pack/src/webapp/vm/morpheus/moresites.vm
+++ b/portal/portal-render-engine-impl/pack/src/webapp/vm/morpheus/moresites.vm
@@ -55,15 +55,12 @@
                             #end
 							
                             <div class="fav-title #if (${site.isMyWorkspace}) fav-title-myworkspace #end">
-                            	<a href="${site.siteUrl}"
+                            	<a href="${site.siteUrl}" title="${site.siteUrl}">
                                     #if (${site.isMyWorkspace})
-                                        title="${rloader.sit_mywor}">
                                         <i class="fa fa-home icon-sakai"></i><span class="fullTitle">${rloader.sit_mywor}</span>
                                     #elseif ( ( ${tabDisplayLabel} == 2 ) && ( ${site.shortDescription} ) )
-                                        title="${site.shortDescription}">
                                         <span class="fullTitle">${site.shortDescription}</span>
                                     #else
-                                        title="${site.siteTitle}">
                                         <span class="fullTitle">${site.siteTitle}</span>
                                     #end
                                 </a>

--- a/reference/library/src/morpheus-master/js/src/sakai.morpheus.more.sites.js
+++ b/reference/library/src/morpheus-master/js/src/sakai.morpheus.more.sites.js
@@ -233,7 +233,7 @@ $PBJQ(document).ready(function(){
       $PBJQ('.fav-sites-term, .fav-sites-entry').hide();
 
       var matched_sites = $PBJQ('.fav-sites-entry').filter(function (idx, entry) {
-          return ($PBJQ('.fav-title a', entry).attr('title').toLowerCase().indexOf(queryString) >= 0);
+          return ($PBJQ('.fav-title a span.fullTitle', entry).text().toLowerCase().indexOf(queryString) >= 0);
       });
 
       matched_sites.show();


### PR DESCRIPTION
This PR is to (i) undo the change in https://github.com/ox-it/sakai/pull/173
        and (ii) to get the Site Drawer search working again but in a different way to the above PR.

I'm undoing the previous fix because the previous fix involved changing the title attribute of each site in the Sites Drawer to be the site name rather than the site url.  This worked but wasn't great because it meant that we lost the ability to hover over 2 sites with the same or very similar names and differentiate them by url.  

This fix is to change the way the filtering works so that it's the same as on live which is just to filter on the span element's content which contains the site name.  
