### PR TITLE
WL-4630 Don’t log about members we can’t parse.

### DIFF
--- a/external-groups/impl/src/main/java/uk/ac/ox/oucs/vle/ExternalGroupManagerImpl.java
+++ b/external-groups/impl/src/main/java/uk/ac/ox/oucs/vle/ExternalGroupManagerImpl.java
@@ -471,7 +471,7 @@ public class ExternalGroupManagerImpl implements ExternalGroupManager {
 						}
 					}
 					catch (ParseException e){
-						log.info("Failed to parse member: "+ member);
+						log.debug("Ignoring non-parsable member: "+ member+ " in group: "+ externalId);
 					}
 				}
 			}


### PR DESCRIPTION
With the change to groupstore we now see other groups as members. We can’t filter out these members on the search as Oak LDAP doesn’t support substring matching on the member attribute.
