### PR TITLE
WL-4637 Folder listing in lessons is fixed.

### DIFF
--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/producers/FolderPickerProducer.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/producers/FolderPickerProducer.java
@@ -91,6 +91,7 @@ public class FolderPickerProducer implements ViewComponentProducer, NavigationCa
             }
             //get site entity-id
             UIInput.make(form, "folder-path", "#{simplePageBean.folderPath}", contentHostingService.getSiteCollection(simplePageBean.getCurrentSiteId()));
+            UIInput.make(form, "add-before", "#{simplePageBean.addBefore}", ((GeneralViewParameters) viewparams).getAddBefore());
             UIInput.make(form, "item-id", "#{simplePageBean.itemId}");
             UICommand.make(form, "submit", messageLocator.getMessage("simplepage.save_message"), "#{simplePageBean.folderPickerSubmit}").decorate(new UITooltipDecorator(messageLocator.getMessage("simplepage.save_message")));
             UICommand.make(form, "cancel", messageLocator.getMessage("simplepage.cancel_message"), "#{simplePageBean.cancel}").decorate(new UITooltipDecorator(messageLocator.getMessage("simplepage.cancel_message")));

--- a/lessonbuilder/tool/src/webapp/templates/FolderPicker.html
+++ b/lessonbuilder/tool/src/webapp/templates/FolderPicker.html
@@ -6,7 +6,7 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 		<META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE"/>
 		<script rsf:id="scr=portal-matter" type="text/javascript" language="JavaScript" src="/library/js/headscripts.js"></script>
-		<script type="text/javascript" src="https://weblearn.ox.ac.uk/library/js/jquery/jquery-1.9.1.min.js"></script>
+		<script type="text/javascript" src="$context/js/jquery-1.9.1.min.js"></script>
 		<script type="text/javascript" src="/library/editor/ckextraplugins/folder-listing/js/file-tree.js"></script>
 		<script type="text/javascript" src="/library/editor/ckextraplugins/folder-listing/js/folder-listing.js"></script>
 		<script type="text/javascript" src="/library/editor/ckextraplugins/folder-listing/js/get-available-sites.js"></script>
@@ -30,6 +30,7 @@
 				<input type="hidden" rsf:id="item-id" id="item-id" />
 				<h3 rsf:id="msg=simplepage.choose.folder"></h3>
 				<input type="hidden" rsf:id="folder-path" id="folder-path" />
+				<input type="hidden" rsf:id="add-before" id="add-before" />
 				<div class="listing"  id="workspace" data-files="true" data-description="true"
 					 data-copyright="true"   data-multifolder="true">
 				</div>


### PR DESCRIPTION
In 'FolderPicker.html' jquery was coming from a url pointing to weblearn
, have changed it to a proper path which points to jquery file in lessons
folder. Have also added 'add-before' param so that folders/file gets added
at the correct place on '+' click instead of getting added at the bottom of
the page all the times.
