### PR TITLE
WL-4647: Access user cannot upload to resources

### DIFF
--- a/content/content-tool/tool/src/java/org/sakaiproject/content/tool/ResourcesHelperAction.java
+++ b/content/content-tool/tool/src/java/org/sakaiproject/content/tool/ResourcesHelperAction.java
@@ -2098,7 +2098,8 @@ public class ResourcesHelperAction extends VelocityPortletPaneledAction
 					collectionId = resourceGroup;
 				}
 				try{
-					//if user has chosen to overwrite existing resource save the new copy
+					//if user has chosen to overwrite existing resource and has correct permissions, save the new copy
+					ContentHostingService.getResource(resourceId);
 					if(overwrite != null && overwrite.equals("true")){
 						resource = ContentHostingService.editResource(resourceId);
 					}


### PR DESCRIPTION
The logic here is that if they have ticked the overwrite checkbox when dragging and drropping a resource then we check they have edit permissions unless the resource itself does not exist in which case they don't need edit permssions they just need create permissions.
