### PR TITLE
WL-4656 Allow maintainers to add LTI tools.

### DIFF
--- a/basiclti/basiclti-tool/src/java/org/sakaiproject/blti/tool/LTIAdminTool.java
+++ b/basiclti/basiclti-tool/src/java/org/sakaiproject/blti/tool/LTIAdminTool.java
@@ -99,6 +99,7 @@ public class LTIAdminTool extends VelocityPortletPaneledAction
 	private static String STATE_LTI2_TOOL_ID = "lti2:state_tool_id";
 
 	private static String ALLOW_MAINTAINER_ADD_SYSTEM_TOOL = "lti:allow_maintainer_add_system_tool";
+	private static String ALLOW_MAINTAINER_ADD_TOOL_SITE = "lti:allow_maintainer_add_tool_site";
 
 	/** Service Implementations */
 	protected static ToolManager toolManager = null; 
@@ -203,6 +204,7 @@ public class LTIAdminTool extends VelocityPortletPaneledAction
 		context.put("contents", contents);
 		context.put("messageSuccess",state.getAttribute(STATE_SUCCESS));
 		context.put("isAdmin",new Boolean(ltiService.isAdmin()) );
+		context.put("allowMaintainerAddToolSite", serverConfigurationService.getBoolean(ALLOW_MAINTAINER_ADD_TOOL_SITE, true));
 		context.put("getContext",toolManager.getCurrentPlacement().getContext());
 		
 		// top navigation menu

--- a/basiclti/basiclti-tool/src/webapp/vm/lti_tool_site.vm
+++ b/basiclti/basiclti-tool/src/webapp/vm/lti_tool_site.vm
@@ -113,7 +113,7 @@ ${includeLatestJQuery}
 	</ul>
 	#if ($messageSuccess)<div class="messageSuccess">$tlang.getString("gen.success") $validator.escapeHtml($messageSuccess)</div><div class="clear"></div>#end
 	#if ($alertMessage)<div class="alertMessage">$tlang.getString("gen.alert") $validator.escapeHtml($alertMessage)</div><div class="clear"></div>#end
-	#if ($isAdmin)
+	#if ($isAdmin || $allowMaintainerAddToolSite)
 	<div align="right"><a href="" title="$tlang.getString("add.to.site")" onclick="location = '$sakai_ActionURL.setPanel("ContentPut")';return false;"> $tlang.getString("add.to.site")</a></div>
 	<br/>
 	$tlang.getString("tool.description.sites")

--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -1967,7 +1967,15 @@
 
 # Suppress portlet form field with supplied secret.
 # DEFAULT: none (null)
-# sakai.testlti.secret= 
+# sakai.testlti.secret=
+
+# Allow maintainers to add new LTI tools to system.
+# DEFAULT true
+# lti:allow_maintainer_add_system_tool=false
+
+# Allow maintainers to add LTI tools to the site (outside manage tools).
+# DEFAULT true
+# lti:allow_maintainer_add_tool_site=false
 
 ## CALENDAR SUMMARY
 # View (week or month)


### PR DESCRIPTION
In Sakai 10 maintainers in a site could add an LTI tool to their site one or more times, in Sakai 11 this is only available to the admin user in the administration workspace. This adds it back and controls it with a property, which defaults to true, to stop maintainers adding multiple tools add:

```
lti:allow_maintainer_add_tool_site=false
```

to sakai.properties.
