### PR TITLE
WL-4629 Allow the roster front page to render (anon)

### DIFF
--- a/roster2/src/java/org/sakaiproject/roster/tool/RosterTool.java
+++ b/roster2/src/java/org/sakaiproject/roster/tool/RosterTool.java
@@ -72,11 +72,6 @@ public class RosterTool extends HttpServlet {
 
 		String userId = sakaiProxy.getCurrentUserId();
 
-		if (null == userId) {
-			// We are not logged in
-			throw new ServletException("getCurrentUser returned null.");
-		}
-
         String siteLanguage = sakaiProxy.getCurrentSiteLocale();
 
         Locale locale = null;


### PR DESCRIPTION
This means the user gets an alert saying they must be logged into use the roster tool. A better fix would be to actually have the message displayed in the page, but there’s lots of startup that needs to happen to get a handlebars template to render and some of these chunks need to have the user logged in.

Allowing anonymous access to the roster tool also needs access to the profile tool and both of them currently have lots of checks which would need to be carefully removed.

This change should stop users seeing an ugly stack trace and if we consider it important we can look at allowing anonymous access to the roster in the future.
