### PR TITLE
WL-4641: HTML tables in user-created content ignore cellpadding/spacing

### DIFF
--- a/reference/library/src/morpheus-master/bootstrap-sass-3.3.6/assets/stylesheets/bootstrap/_normalize.scss
+++ b/reference/library/src/morpheus-master/bootstrap-sass-3.3.6/assets/stylesheets/bootstrap/_normalize.scss
@@ -414,11 +414,15 @@ optgroup {
 //
 
 table {
-  border-collapse: collapse;
-  border-spacing: 0;
+  @media #{$phone}{
+    border-collapse: collapse;
+    border-spacing: 0;
+  }
 }
 
 td,
 th {
-  padding: 0;
+  @media #{$phone}{
+    padding: 0;
+  }
 }


### PR DESCRIPTION
The general problem here is that bootstrap/morpheus code is setting the cellspacing and cellpadding to 0 and overwriting/ignoring any cellspacing/cellpadding attributes that are set (by the user or elsewhere in the code).  The reason I'm guessing this is in the code is for responsiveness, so that there isn't any unneeded whitespace on tables on eg phones.  

This change applies this overwriting of the attributes only to phones etc.  
