### PR TITLE
WL-4666: Adding resources folder - see footer half way down the page

### DIFF
--- a/lessonbuilder/tool/src/webapp/templates/FolderPicker.html
+++ b/lessonbuilder/tool/src/webapp/templates/FolderPicker.html
@@ -17,7 +17,7 @@
 		<script type="text/javascript" src="$context/js/folder-picker.js"></script>
 	</head>
 	<body rsf:id="scr=sakai-body">
-		<div class="portletBody" style="height:800px;">
+		<div class="portletBody">
 			<div rsf:id="error-div" class="ui-widget">
 				<div class="ui-state-error ui-corner-all" style="margin-bottom: 20px; margin-top:20px; padding: 0 .7em;"> 
 					<p><span class="ui-icon ui-icon-info" style="float: left; margin-right: .3em;"></span>


### PR DESCRIPTION
By removing this styling 'height=800px' it gets the default 'height=auto' which lets the browser do the work.
