### PR TITLE
WL-1294: Drop the filtering of the site description.

### DIFF
--- a/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
+++ b/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
@@ -8618,7 +8618,7 @@ private Map<String,List> getTools(SessionState state, String type, Site site) {
 		}
 
 		//Process description so it doesn't give an error on home
-		siteInfo.description = FormattedText.processFormattedText(siteInfo.description, new StringBuilder());
+		siteInfo.description = StringUtils.trimToNull(siteInfo.description);
 		
 		Site.setDescription(siteInfo.description);
 		Site.setShortDescription(siteInfo.short_description);


### PR DESCRIPTION
Currently, if you edit the site description via the Overview tool and add a https:// link in the ck editor it does _not_ add a 'target=_blank' attribute to it but if you do it in the Site Info -> Manage Site Information tool it does.  We want the Site Info tool to work the same as the Overview tool.  The salient difference between the two is that in the Overview tool the description is manipulated like this:

(Line 897, PortletIFrame.java)
String description = StringUtils.trimToNull(request.getParameter("description"));

where as in the Site Info tool this is done:

(Line 8621, SiteAction.java):
siteInfo.description = FormattedText.processFormattedText(siteInfo.description, new StringBuilder()); 

This change is to replace the Site Info way with the Overview way. 
