### PR TITLE
WL-4672 Made LB-CSS folder hidden by default.

### DIFF
--- a/jobscheduler/scheduler-component-shared/src/java/org/sakaiproject/component/app/scheduler/jobs/LBCSSFolderHideJob.java
+++ b/jobscheduler/scheduler-component-shared/src/java/org/sakaiproject/component/app/scheduler/jobs/LBCSSFolderHideJob.java
@@ -1,0 +1,95 @@
+package org.sakaiproject.component.app.scheduler.jobs;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.quartz.DisallowConcurrentExecution;
+import org.quartz.Job;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.sakaiproject.content.api.ContentCollectionEdit;
+import org.sakaiproject.content.api.ContentHostingService;
+import org.sakaiproject.db.api.SqlService;
+import org.sakaiproject.entity.api.ResourceProperties;
+import org.sakaiproject.entity.api.ResourcePropertiesEdit;
+import org.sakaiproject.event.api.UsageSessionService;
+import org.sakaiproject.exception.*;
+import org.sakaiproject.tool.api.Session;
+import org.sakaiproject.tool.api.SessionManager;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.util.List;
+
+/**
+ * Job to make LB-CSS folder hidden but contents accessible.
+ * LB-CSS folder should not be visible to access user, this job will hide all existing non-hidden LB-CSS folder.
+ * @author neelam
+ *
+ */
+@DisallowConcurrentExecution
+public class LBCSSFolderHideJob implements Job {
+
+	private SqlService sqlService;
+	private SessionManager sessionManager;
+
+	private static final Log LOG = LogFactory.getLog(LBCSSFolderHideJob.class);
+	
+	private ContentHostingService contentHostingService;
+
+	public void setSqlService(SqlService sqlService) {
+		this.sqlService = sqlService;
+	}
+
+	public void setSessionManager(SessionManager sessionManager) {
+		this.sessionManager = sessionManager;
+	}
+
+	public void setContentHostingService(ContentHostingService contentHostingService) {
+		this.contentHostingService = contentHostingService;
+	}
+
+	public void execute(JobExecutionContext context) throws JobExecutionException {
+		ContentCollectionEdit contentCollectionEdit;
+		ResourcePropertiesEdit resourceProperties;
+		Session session = null;
+		//sql to get collection ids for all LB-CSS folder
+		String sql = "SELECT COLLECTION_ID FROM CONTENT_COLLECTION WHERE COLLECTION_ID LIKE \"%LB-CSS/\" ";
+		LOG.debug("SQL to get collection Id for LB-CSS folder " + sql);
+		int totalFolders = 0 , foldersUpdated = 0, foldersAlreadySet = 0;
+		//set current user in session
+		try {
+			session = sessionManager.getCurrentSession();
+			session.setUserEid("admin");
+			session.setUserId("admin");
+			List<String> collection_ids = sqlService.dbRead(sql);
+			totalFolders = collection_ids.size();
+			LOG.info("Number of LB-CSS folders found is " + totalFolders);
+			for (String id : collection_ids) {
+				try {
+					contentCollectionEdit = contentHostingService.editCollection(id);
+					resourceProperties = contentCollectionEdit.getPropertiesEdit();
+					//if LB-CSS folder is not hidden, hide it
+					if (!("true".equals(resourceProperties.getProperty(ResourceProperties.PROP_HIDDEN_WITH_ACCESSIBLE_CONTENT)))) {
+						resourceProperties.addProperty(ResourceProperties.PROP_HIDDEN_WITH_ACCESSIBLE_CONTENT, "true");
+						foldersUpdated++;
+						LOG.info("Hiding the collection" + id +  " from access user ");
+						contentHostingService.commitCollection(contentCollectionEdit);
+					}
+					else {
+						foldersAlreadySet++;
+						contentHostingService.cancelCollection(contentCollectionEdit);
+						LOG.info("The collection " + id +" has already been hidden ");
+					}
+				} catch (SakaiException exception) {
+					LOG.error("Failed to update the LB-CSS folder: " + id, exception);
+				}
+			}
+		}
+		finally {
+			LOG.info("Summary of LBCSSFolderHideJob , Total LB-CSS folders: " + totalFolders + " Updated: " +
+					foldersUpdated + " Collection already hidden: " + foldersAlreadySet);
+			session.invalidate();
+		}
+	}
+
+}

--- a/jobscheduler/scheduler-component/src/webapp/WEB-INF/components.xml
+++ b/jobscheduler/scheduler-component/src/webapp/WEB-INF/components.xml
@@ -423,4 +423,26 @@
          <ref bean="org.sakaiproject.api.app.scheduler.SchedulerManager" />
       </property>
    </bean>
+
+    <!-- Hide LB-CSS folder from access user-->
+    <bean id = "org.sakaiproject.component.app.scheduler.jobs.LBCSSFolderHideJob"
+          class="org.sakaiproject.component.app.scheduler.jobs.LBCSSFolderHideJob">
+        <property name="sqlService" ref="org.sakaiproject.db.api.SqlService"/>
+        <property name="sessionManager" ref="org.sakaiproject.tool.api.SessionManager"/>
+        <property name="contentHostingService" ref="org.sakaiproject.content.api.ContentHostingService"/>
+    </bean>
+
+    <bean id="org.sakaiproject.api.app.scheduler.JobBeanWrapper.LBCSSFolderHideJob"
+        class="org.sakaiproject.component.app.scheduler.jobs.SpringJobBeanWrapper"
+        init-method="init">
+        <property name="beanId">
+            <value>org.sakaiproject.component.app.scheduler.jobs.LBCSSFolderHideJob</value>
+        </property>
+        <property name="jobName">
+            <value>Hide LB-CSS folder in Resources.</value>
+        </property>
+        <property name="schedulerManager">
+            <ref bean="org.sakaiproject.api.app.scheduler.SchedulerManager" />
+        </property>
+    </bean>
 </beans>

--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/beans/SimplePageBean.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/beans/SimplePageBean.java
@@ -4102,6 +4102,8 @@ public class SimplePageBean {
 				try {
 					ContentCollectionEdit edit = contentHostingService.addCollection(collectionId);
 					edit.getPropertiesEdit().addProperty(ResourceProperties.PROP_DISPLAY_NAME, "LB-CSS");
+					//this folder should be hidden from access user
+					edit.getPropertiesEdit().addProperty(ResourceProperties.PROP_HIDDEN_WITH_ACCESSIBLE_CONTENT, "true");
 					contentHostingService.commitCollection(edit);
 				}catch(Exception e) {
 					setErrMessage(messageLocator.getMessage("simplepage.permissions-general"));


### PR DESCRIPTION
In SimplePageBean class when LB-CSS folder is added in resources, the
PROP_HIDDEN_WITH_ACCESSIBLE_CONTENT property is set to true for the folder.

For the existing LB-CSS folders in database a new job(class) -
LBCSSFolderHideJob is added. When this job is run , it will hide all the
visible LB-CSS folders from access users.
