### PR TITLE
WL-3992 Folders with long name will be displayed correctly in Lessons.

### DIFF
--- a/reference/library/src/webapp/editor/ckextraplugins/folder-listing/css/file-tree.css
+++ b/reference/library/src/webapp/editor/ckextraplugins/folder-listing/css/file-tree.css
@@ -11,7 +11,6 @@ ul.jqueryFileTree li {
   padding: 0px;
   padding-left: 23px;
   margin: 0px;
-  white-space: nowrap;
   background-position: 3px 3px;
   background-repeat: no-repeat;
   position: relative;


### PR DESCRIPTION
Have removed 'white-space: nowrap' property from 'file-tree.css' so that
folders with long names are displayed correctly , when added in Lessons.
