### PR TITLE
WL-4641: HTML tables in user-created content ignore cellpadding/spacing

### DIFF
--- a/reference/library/src/morpheus-master/bootstrap-sass-3.3.6/assets/stylesheets/bootstrap/_normalize.scss
+++ b/reference/library/src/morpheus-master/bootstrap-sass-3.3.6/assets/stylesheets/bootstrap/_normalize.scss
@@ -405,24 +405,3 @@ textarea {
 optgroup {
   font-weight: bold;
 }
-
-// Tables
-// ==========================================================================
-
-//
-// Remove most spacing between table cells.
-//
-
-table {
-  @media #{$phone}{
-    border-collapse: collapse;
-    border-spacing: 0;
-  }
-}
-
-td,
-th {
-  @media #{$phone}{
-    padding: 0;
-  }
-}


### PR DESCRIPTION
After discussing with Matthew+Adam, we decided to preserve all (user generated) cellpadding/spacing so this code needs to be ripped out. 
