### PR TITLE
WL-3054: Mouse-over site URL in My Active Sites list

### DIFF
--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/site/PortalSiteHelperImpl.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/site/PortalSiteHelperImpl.java
@@ -404,7 +404,7 @@ public class PortalSiteHelperImpl implements PortalSiteHelper
 				+ ServerConfigurationService.getString("portalPath") + "/";
 		if (prefix != null) siteUrlPrefix = siteUrlPrefix + prefix + "/";
 		// siteUrl = siteUrl + Web.escapeUrl(siteHelper.getSiteEffectiveId(s));
-		m.put("siteUrl", siteUrlPrefix + Web.escapeUrl(getSiteEffectiveId(s)));
+		m.put("siteUrl", siteUrlPrefix + Web.escapeUrl(getSiteEffectiveId(s)).replaceAll("%3A",":"));
 		m.put("siteType", s.getType());
 		m.put("siteId", s.getId());
 


### PR DESCRIPTION
The problem is that when the hover-over text for a site in My Sites is being processed, which is the site url, the url is escaped which replaces the colons with %3As amongst other things. This change is to replace them back.  
