### PR TITLE
WL-3255 Don’t allow deletion of !hierarchy.missing

### DIFF
--- a/tetraelf-hierarchy/hierarchy-api/api/src/java/org/sakaiproject/hierarchy/api/PortalHierarchyService.java
+++ b/tetraelf-hierarchy/hierarchy-api/api/src/java/org/sakaiproject/hierarchy/api/PortalHierarchyService.java
@@ -161,7 +161,13 @@ public interface PortalHierarchyService {
 	 * @throws PermissionException If you don't have permission to move the node.
 	 */
 	void moveNode(String id, String newParent) throws PermissionException;
-	
+
+	/**
+	 * Gets the ID of the missing site that is used when the actual site couldn't be found.
+	 * @return The site ID of the missing site.
+	 */
+	String getMissingSiteId();
+
 	/**
 	 * Change the located at a node.
 	 * @param id The ID of the node to update.

--- a/tetraelf-hierarchy/hierarchy-impl/impl/src/java/org/sakaiproject/hierarchy/impl/PortalHierarchyServiceImpl.java
+++ b/tetraelf-hierarchy/hierarchy-impl/impl/src/java/org/sakaiproject/hierarchy/impl/PortalHierarchyServiceImpl.java
@@ -87,6 +87,11 @@ public class PortalHierarchyServiceImpl implements PortalHierarchyService {
 	 */
 	private String missingSiteId;
 
+	@Override
+	public String getMissingSiteId() {
+		return missingSiteId;
+	}
+
 	private boolean autoDDL;
 
 	public void changeSite(String id, String newSiteId) throws PermissionException {

--- a/tetraelf-hierarchy/hierarchy-tool/tool/src/webapp/WEB-INF/velocity/delete.vm
+++ b/tetraelf-hierarchy/hierarchy-tool/tool/src/webapp/WEB-INF/velocity/delete.vm
@@ -27,7 +27,8 @@
 	<p class="instructions">
 		<label for="deleteSite">#springMessage("delete.site")</label>
 		#springBind("command.deleteSite")
-		<input type="checkbox" id="${status.expression}" name="${status.expression}">
+		<input type="checkbox" id="${status.expression}" name="${status.expression}" #if(!${canDeleteSite})disabled#end>
+		#if(!${canDeleteSite})<span class="alertMessageInline">#springMessage("delete.cannot")</span>#end
 		<br/>
 	</p>
 	#end


### PR DESCRIPTION
This also means that we display a better message when the user can’t delete the site but can remove the node. However the terminology is still confusing and could do with further work. This is a belt and braces solution which updates the template to stop users getting the option but also updates the server side code to do the check there as well.
