### PR TITLE
WL-1610 EVALSYS-1073 mouseover text incorrect

### DIFF
--- a/evaluations/tool/src/webapp/content/js/utils.js
+++ b/evaluations/tool/src/webapp/content/js/utils.js
@@ -148,6 +148,20 @@ evalsys.instrumentBlockItem = function(){
         $(this).find('.actualHeader').each(function(){
             headerCol.push($(this).text());
         });
+
+        /*
+         Fix tool tips for Rating Scale items without an N/A value
+         */
+        var foundNA = false;
+        jQuery.each(headerCol, function(i,value) {
+            if (value == 'Not applicable') {
+                foundNA = true;
+            }
+        });
+        if (!foundNA) {
+            headerCol.push("");
+        }
+
         /*
          add to the headerCol the header string values for the NA choice if present
          */


### PR DESCRIPTION
This fixes the hover text on evaluations when there is a not applicable option for a grouped rating scale.
Re-apply of a patch that got lost in the upgrade.