### PR TITLE
WL-4753 WL-4690: Paste icons are insanely small

### DIFF
--- a/reference/library/src/morpheus-master/sass/modules/tool/resources/_resources.scss
+++ b/reference/library/src/morpheus-master/sass/modules/tool/resources/_resources.scss
@@ -123,9 +123,6 @@
 		display: inline;
 		font-size:1em;
 	}
-	.table .attach {
-	width:20px !important;
-	}
 	td.actions2 .dropdown-toggle {
 		padding: 2px 6px !important;
 	}


### PR DESCRIPTION
This is a fallout from WL-4690.  The fix here is to override the css from WL-4690 by creating a class for the paste icon.