### PR TITLE
WL-4757: Block elements are centred, bold and are small

### DIFF
--- a/evaluations/tool/src/webapp/component-templates/render_multipleanswer_item.html
+++ b/evaluations/tool/src/webapp/component-templates/render_multipleanswer_item.html
@@ -30,7 +30,7 @@
                 <!-- Full, Vertical DISPLAY -->
                <span class="validFailGlyph">*</span><span class="compulsoryGlyph">*</span>
                <span rsf:id="itemNum" class="label firstItem">#</span><span class="label">.&nbsp;</span>
-               <div rsf:id="itemText" style="display:inline" class="label longLabel">Full or vertical display text here</div>
+               <div rsf:id="itemText" style="display:inline" class="longLabel">Full or vertical display text here</div>
 
                <div class="content">
                <div rsf:id="nextrow:">

--- a/evaluations/tool/src/webapp/component-templates/render_multiplechoice_item.html
+++ b/evaluations/tool/src/webapp/component-templates/render_multiplechoice_item.html
@@ -30,7 +30,7 @@
                <!-- Full, Vertical DISPLAY -->
                <span class="validFailGlyph">*</span><span class="compulsoryGlyph">*</span>
                <span rsf:id="itemNum" class="label firstItem">#</span><span class="label">.&nbsp;</span>
-               <div rsf:id="itemText" style="display:inline" class="label longLabel">Full or vertical display text here</div>
+               <div rsf:id="itemText" style="display:inline" class="longLabel">Full or vertical display text here</div>
 
                <div rsf:id="nextrow:" class="content">
 

--- a/evaluations/tool/src/webapp/component-templates/render_scaled_item.html
+++ b/evaluations/tool/src/webapp/component-templates/render_scaled_item.html
@@ -30,7 +30,7 @@
 				<div style="padding:.3em 0;">
                      <span class="validFailGlyph">*</span><span class="compulsoryGlyph">*</span>
                      <span rsf:id="itemNum" class="label firstItem">#</span><span class="label">.&nbsp;</span>
-                     <span rsf:id="itemText" style="display:inline" class="label longLabel">Item text for compact items goes here</span>
+                     <span rsf:id="itemText" style="display:inline" class="longLabel">Item text for compact items goes here</span>
 				</div>
 				<div class="content">
 				<table border="0" cellspacing="0" cellpadding="0" width="10%" class="itemScalePanel" >
@@ -79,7 +79,7 @@
 				<!-- Full, Full Colored, Vertical DISPLAY -->
 					<p style="padding-right:100px;">
 						<span class="validFailGlyph">*</span><span class="compulsoryGlyph">*</span> <span rsf:id="itemNum" class="label firstItem">#</span><span class="label">.&nbsp;</span>
-						<span rsf:id="itemText" style="display:inline" class="label longLabel">Full or vertical display text here</span>
+						<span rsf:id="itemText" style="display:inline" class="longLabel">Full or vertical display text here</span>
 					</p>
 
 				<!-- Next row for Full Display, Full Colored, Vertical Display -->
@@ -269,7 +269,7 @@
 								<tr>
 									<td width="90%" valign="top">
 											<span class="validFailGlyph">*</span><span class="compulsoryGlyph">*</span> <span rsf:id="itemNum" class="label firstItem">#</span><span class="label">.&nbsp;</span>
-											<div rsf:id="itemText"  style="display:inline" class="label longLabel">Stepped item text here</div>
+											<div rsf:id="itemText"  style="display:inline" class="longLabel">Stepped item text here</div>
 									</td>
 									<td align="right" style="white-space:nowrap" valign="middle" class="exclude NACell">
 										<span class="itemDoneCheck">&nbsp;&nbsp;&nbsp;&nbsp;</span>

--- a/evaluations/tool/src/webapp/component-templates/render_text_item.html
+++ b/evaluations/tool/src/webapp/component-templates/render_text_item.html
@@ -26,7 +26,7 @@
 		<!-- html template for the text item renderer -AZ -->
 		<div rsf:id="render-text-item:" class="item text">
 				<span rsf:id="itemNum" class="label firstItem">0</span><span class="label">.&nbsp;</span>
-				<div rsf:id="itemText" style="display:inline" class="label longLabel"></div>
+				<div rsf:id="itemText" style="display:inline" class="longLabel"></div>
 			<div class="content">
 				<textarea rsf:id="essayBox" cols="65" rows="3" style="display:block"></textarea>
 				<label rsf:id="showNA:">


### PR DESCRIPTION
The label class is causing the question text to be bold, centered and 75% so I'm removing it.    