### PR TITLE
WL-4765 Use BasicLTI’s new query language.

### DIFF
--- a/basiclti/basiclti-api/src/java/org/sakaiproject/lti/api/LTIService.java
+++ b/basiclti/basiclti-api/src/java/org/sakaiproject/lti/api/LTIService.java
@@ -946,6 +946,7 @@ public interface LTIService {
 	public static final String ESCAPED_LTI_SEARCH_TOKEN_SEPARATOR_OR = "\\#\\|\\#";
 	public static final String LTI_SEARCH_TOKEN_NULL = "#null#";
 	public static final String LTI_SEARCH_TOKEN_DATE = "#date#";
+	public static final String LTI_SEARCH_TOKEN_EXACT = "#exact#";
 	public static final String LTI_SEARCH_INTERNAL_DATE_FORMAT = "dd/MM/yyyy H:mm:ss";
 	public static final String LTI_SITE_ATTRIBUTION_PROPERTY_KEY = "basiclti.tool.site.attribution.key";
 	public static final String LTI_SITE_ATTRIBUTION_PROPERTY_KEY_DEFAULT = "Department";

--- a/basiclti/basiclti-impl/src/java/org/sakaiproject/lti/impl/LTIReportingJob.java
+++ b/basiclti/basiclti-impl/src/java/org/sakaiproject/lti/impl/LTIReportingJob.java
@@ -14,6 +14,9 @@ import org.sakaiproject.user.api.User;
 import org.sakaiproject.util.ResourceLoader;
 
 import java.text.DateFormat;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalUnit;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -52,9 +55,11 @@ public class LTIReportingJob implements Job {
 
         String toolTitle = (String) tool.get("title");
 
-        // SELECT * FROM lti_content where tool_id = ? created_at > date_sub(now(),  interval ???? second) ;
-        String search = String.format("tool_id = %d AND created_at > date_sub(now(), interval %d second)",
-            toolId, period / 1000);
+        DateFormat sqlDf = DateFormat.getDateTimeInstance(DateFormat.MEDIUM, DateFormat.MEDIUM, rb.getLocale());
+        Instant instant = Instant.now().minus(period, ChronoUnit.MILLIS);
+        String fromDate = sqlDf.format(Date.from(instant));
+
+        String search = "tool_id:"+ "#exact#"+ toolId+ "#&#"+ "created_at:"+ "#date#>"+ fromDate ;
         List<Map<String, Object>> contents = ltiService.getContentsDao(search, null, 0, 0, null);
         DateFormat df = DateFormat.getDateTimeInstance( DateFormat.SHORT, DateFormat.SHORT, rb.getLocale());
 

--- a/basiclti/basiclti-impl/src/java/org/sakaiproject/util/foorm/Foorm.java
+++ b/basiclti/basiclti-impl/src/java/org/sakaiproject/util/foorm/Foorm.java
@@ -1537,17 +1537,30 @@ public class Foorm {
 					searchValue = searchValue.replace(LTIService.LTI_SEARCH_TOKEN_DATE, "");
 					if(StringUtils.isNotEmpty(searchValue)) {
 						try {
+							String operator = "=";
+							// Support more searching on dates.
+							if (searchValue.startsWith("<")) {
+								operator = "<";
+								searchValue = searchValue.substring(1);
+							} else if (searchValue.startsWith(">")) {
+								operator = ">";
+								searchValue = searchValue.substring(1);
+							}
 							DateFormat df = DateFormat.getDateTimeInstance(DateFormat.MEDIUM, DateFormat.MEDIUM, rb.getLocale());
 							Date d = df.parse(searchValue);
-							
+
 							DateFormat sql_df = new SimpleDateFormat(LTIService.LTI_SEARCH_INTERNAL_DATE_FORMAT);
 							if ( "oracle".equals(vendor) ) {
-								sb.append(searchField + " = TO_DATE('"+sql_df.format(d)+"', 'DD/MM/YYYY HH24:MI:SS')");
+								sb.append(searchField + " "+operator+ " TO_DATE('"+sql_df.format(d)+"', 'DD/MM/YYYY HH24:MI:SS')");
 							} else if ( "mysql".equals(vendor) ) {
-								sb.append(searchField + " = STR_TO_DATE('"+sql_df.format(d)+"', '%d/%m/%Y %H:%i:%s')");
+								sb.append(searchField + " "+ operator+ " STR_TO_DATE('"+sql_df.format(d)+"', '%d/%m/%Y %H:%i:%s')");
 							}
 						} catch(Exception ignore) {}
 					}
+				} else if (searchValue.startsWith(LTIService.LTI_SEARCH_TOKEN_EXACT)) {
+					searchValue = searchValue.replace(LTIService.LTI_SEARCH_TOKEN_EXACT, "");
+					sb.append(searchField + " = ?");
+					ret.addSearchValue(searchValue);
 				} else {
 					sb.append(searchField + " LIKE ?");
 					searchValue = searchValue.replace(LTIService.ESCAPED_LTI_SEARCH_TOKEN_SEPARATOR_AND, LTIService.LTI_SEARCH_TOKEN_SEPARATOR_AND);


### PR DESCRIPTION
The old SQL query was getting thrown away as it couldn’t be parsed correctly. This adds support for the missing features we needed in the query API and then uses them.