### PR TITLE
WL-4761 Allow admin tool is sites other than !admin.

### DIFF
--- a/basiclti/basiclti-impl/src/java/org/sakaiproject/lti/impl/BaseLTIService.java
+++ b/basiclti/basiclti-impl/src/java/org/sakaiproject/lti/impl/BaseLTIService.java
@@ -21,10 +21,6 @@
 
 package org.sakaiproject.lti.impl;
 
-import java.util.UUID;
-import java.util.List;
-import java.util.Map;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sakaiproject.authz.api.SecurityService;
@@ -47,8 +43,12 @@ import org.sakaiproject.util.ResourceLoader;
 import org.sakaiproject.util.foorm.SakaiFoorm;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 import java.util.Map;
 import java.util.Properties;
+import java.util.UUID;
 
 /**
  * <p>
@@ -358,7 +358,11 @@ public abstract class BaseLTIService implements LTIService {
 		if ( siteId == null ) {
 			throw new java.lang.RuntimeException("isAdmin() requires non-null siteId");
 		}
-		if (!ADMIN_SITE.equals(siteId) ) return false;
+		String[] adminSites = serverConfigurationService.getStrings("basiclti.admin.sites");
+		if (adminSites.length == 0) {
+			adminSites = new String[]{"!admin"};
+		}
+		if (!Arrays.asList(adminSites).contains(siteId)) return false;
 		return isMaintain(siteId);
 	}
 

--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -1992,6 +1992,10 @@
 # DEFAULT: content.attribution
 # basiclti.tool.site.attribution.name=content.attribution
 
+# The sites in which the external tool works as an admin tool.
+# DEFAULT: !admin
+# basiclti.admin.sites=!admin,other-site
+
 # Suppress portlet form field with supplied launch end-point URL.
 # DEFAULT: none (null)
 # sakai.testlti.launch=


### PR DESCRIPTION
This allows people other than Sakai administrators to use the LTI admin tool.