### PR TITLE
WL-4745: Entity Broker error with attachment

### DIFF
--- a/msgcntr/messageforums-component-impl/src/java/org/sakaiproject/component/app/messageforums/MessageForumsMessageManagerImpl.java
+++ b/msgcntr/messageforums-component-impl/src/java/org/sakaiproject/component/app/messageforums/MessageForumsMessageManagerImpl.java
@@ -2227,6 +2227,7 @@ public class MessageForumsMessageManagerImpl extends HibernateDaoSupport impleme
 					tempMsg = (Message)results[0];
 					tempMsg.setTopic((Topic)results[1]);
 					tempMsg.getTopic().setBaseForum((BaseForum)results[2]);
+					getHibernateTemplate().initialize(tempMsg.getAttachments());
 				}
 				resultSet.add(tempMsg);
 			}


### PR DESCRIPTION
The error was that the attachments were being accessed outside of the hibernate session so the fix is to initiaize them while we're in the session. 