### PR TITLE
WL-4505 Keep property updated on managed sites.

### DIFF
--- a/docker/sakai/placeholder.properties
+++ b/docker/sakai/placeholder.properties
@@ -821,6 +821,9 @@ basiclti.outcomes.enabled=true
 # Allow the external tool to work in admin mode in more than just the admin workspace.
 basiclti.admin.sites=!admin,!lti-admin
 
+# Set our department.
+basiclti.tool.site.attribution.key=department
+
 # Cache settings for LDAP course owners
 memory.uk.ac.ox.oucs.vle.UniquePathHandler.courseOwnersCache=maxElementsInMemory=10,timeToLiveSeconds=3600,timeToIdleSeconds=3600
 

--- a/kernel/api/src/main/java/org/sakaiproject/authz/api/DevolvedSakaiSecurity.java
+++ b/kernel/api/src/main/java/org/sakaiproject/authz/api/DevolvedSakaiSecurity.java
@@ -64,5 +64,6 @@ public interface DevolvedSakaiSecurity {
 	public boolean canUseAdminRealm(String entityRef);
 	
 	public boolean canRemoveAdminRealm(String entityRef);
-	
+
+	public String getAdminSiteType();
 }

--- a/kernel/kernel-component/src/main/webapp/WEB-INF/components.xml
+++ b/kernel/kernel-component/src/main/webapp/WEB-INF/components.xml
@@ -26,4 +26,29 @@
             lazy-init="false" >
      </bean>
 
+    <bean class="org.sakaiproject.authz.impl.DepartmentSiteAdvisor"
+          init-method="init" destroy-method="destroy">
+        <property name="devolvedSakaiSecurity" ref="org.sakaiproject.authz.api.DevolvedSakaiSecurity"/>
+        <property name="entityManager" ref="org.sakaiproject.entity.api.EntityManager"/>
+        <property name="eventTrackingService" ref="org.sakaiproject.event.api.EventTrackingService"/>
+        <property name="siteProperty">
+            <bean class="org.springframework.beans.factory.config.MethodInvokingFactoryBean">
+                <property name="targetObject">
+                    <ref bean="org.sakaiproject.component.api.ServerConfigurationService"/>
+                </property>
+                <property name="targetMethod">
+                    <value>getString</value>
+                </property>
+                <property name="arguments">
+                    <list>
+                        <value>basiclti.tool.site.attribution.key</value>
+                        <!-- The default value probably won't be any use but it allows startup -->
+                        <value>department</value>
+                    </list>
+                </property>
+            </bean>
+        </property>
+        <property name="siteService" ref="org.sakaiproject.site.api.SiteService"/>
+    </bean>
+
 </beans>

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/authz/impl/DepartmentSiteAdvisor.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/authz/impl/DepartmentSiteAdvisor.java
@@ -1,0 +1,152 @@
+package org.sakaiproject.authz.impl;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.sakaiproject.authz.api.DevolvedSakaiSecurity;
+import org.sakaiproject.entity.api.Entity;
+import org.sakaiproject.entity.api.EntityManager;
+import org.sakaiproject.entity.api.Reference;
+import org.sakaiproject.entity.api.ResourcePropertiesEdit;
+import org.sakaiproject.event.api.Event;
+import org.sakaiproject.event.api.EventTrackingService;
+import org.sakaiproject.exception.IdUnusedException;
+import org.sakaiproject.exception.PermissionException;
+import org.sakaiproject.site.api.Site;
+import org.sakaiproject.site.api.SiteAdvisor;
+import org.sakaiproject.site.api.SiteService;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Observable;
+import java.util.Observer;
+
+/**
+ * This sets a property on a managed Site to the title of it's admin site.
+ * This is useful so that we can do reporting on sites based on their admin site without having to look them up
+ * in the database. The original work was to allow reporting on LTI tools, so they show their affiliation in the
+ * dashboard.
+ */
+public class DepartmentSiteAdvisor implements SiteAdvisor, Observer {
+
+    private final Log log = LogFactory.getLog(DepartmentSiteAdvisor.class);
+
+    private DevolvedSakaiSecurity devolvedSakaiSecurity;
+    private SiteService siteService;
+    private EntityManager entityManager;
+    private EventTrackingService eventTrackingService;
+    private String siteProperty;
+
+    public void setDevolvedSakaiSecurity(DevolvedSakaiSecurity devolvedSakaiSecurity) {
+        this.devolvedSakaiSecurity = devolvedSakaiSecurity;
+    }
+
+    public void setSiteService(SiteService siteService) {
+        this.siteService = siteService;
+    }
+
+    public void setEntityManager(EntityManager entityManager) {
+        this.entityManager = entityManager;
+    }
+
+    public void setEventTrackingService(EventTrackingService eventTrackingService) {
+        this.eventTrackingService = eventTrackingService;
+    }
+
+    public void setSiteProperty(String siteProperty) {
+        this.siteProperty = siteProperty;
+    }
+
+    public void init() {
+        Objects.requireNonNull(devolvedSakaiSecurity);
+        Objects.requireNonNull(siteService);
+        Objects.requireNonNull(entityManager);
+        Objects.requireNonNull(eventTrackingService);
+        Objects.requireNonNull(siteProperty);
+        siteService.addSiteAdvisor(this);
+        eventTrackingService.addLocalObserver(this);
+    }
+
+    public void destroy() {
+        siteService.removeSiteAdvisor(this);
+        eventTrackingService.deleteObserver(this);
+    }
+
+    @Override
+    public void update(Site site) {
+        updateSite(site);
+    }
+
+    @Override
+    public void update(Observable o, Object arg) {
+        // This catches changes to an admin realm change
+        if (arg instanceof Event) {
+            Event event = (Event) arg;
+            if (DevolvedSakaiSecurityImpl.ADMIN_REALM_CHANGE.equals(event.getEvent())) {
+                Reference reference = entityManager.newReference(event.getResource());
+                Entity entity = reference.getEntity();
+                if (entity instanceof Site) {
+                    Site site = (Site)entity;
+                    updateSite(site);
+                    try {
+                        siteService.save(site);
+                    } catch (IdUnusedException e) {
+                        log.warn("Failed to find site when admin realm changed: "+ site.getId(), e);
+                    } catch (PermissionException e) {
+                        log.warn("No permission to change site when changing admin realm: "+ site.getId(), e);
+                    }
+                }
+            } else if (SiteService.SECURE_UPDATE_SITE.equals(event.getEvent())) {
+                Reference reference = entityManager.newReference(event.getResource());
+                Entity entity = reference.getEntity();
+                if (entity instanceof Site) {
+                    Site site = (Site) entity;
+                    updateAllSites(site);
+                }
+            }
+        }
+    }
+
+    private void updateSite(Site site) {
+        String adminRealm = devolvedSakaiSecurity.getAdminRealm(site.getReference());
+        if (adminRealm != null) {
+            Reference reference = entityManager.newReference(adminRealm);
+            Entity entity = reference.getEntity();
+            if (entity instanceof Site) {
+                Site adminSite = (Site)entity;
+                String adminTitle = adminSite.getTitle();
+                site.getProperties().addProperty(siteProperty, adminTitle);
+                log.debug("Set property("+ siteProperty+ ") on site: "+ site.getId()+ " from  "+ adminRealm);
+            }
+        } else {
+            site.getProperties().removeProperty(siteProperty);
+            // There won't be an admin site when the first save is made, but then afterwards when pages are added and
+            // updated there will.
+            log.debug("Removing property on site: "+ site.getId()+ " as no admin realm.");
+        }
+    }
+
+    public void updateAllSites(Site site) {
+        if (devolvedSakaiSecurity.getAdminSiteType().equals(site.getType())) {
+            // Update all the sites using this.
+            List<Entity> managed = devolvedSakaiSecurity.findUsesOfAdmin(site.getReference());
+            for (Entity entity : managed ) {
+                if (entity instanceof Site) {
+                    Site managedSite = (Site) entity;
+                    ResourcePropertiesEdit properties = managedSite.getPropertiesEdit();
+                    if (!properties.getProperty(siteProperty).equals(site.getTitle())) {
+                        properties.addProperty(siteProperty, site.getTitle());
+                        try {
+                            siteService.save(managedSite);
+                        } catch (IdUnusedException e) {
+                            log.warn("Failed to find site we just loaded: "+ managedSite.getId(), e);
+                        } catch (PermissionException e) {
+                            log.warn("No permission to save managed site: "+ managedSite.getId(), e);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+
+}

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/authz/impl/DevolvedSakaiSecurityImpl.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/authz/impl/DevolvedSakaiSecurityImpl.java
@@ -195,10 +195,11 @@ public abstract class DevolvedSakaiSecurityImpl extends SakaiSecurity implements
 		return sites;
 	}
 	
-	public void removeAdminRealm(String adminRealm) throws PermissionException {
-		Reference ref = getSiteReference(adminRealm);
-		if (canRemoveAdminRealm(adminRealm)) {
-			dao().delete(adminRealm);
+	public void removeAdminRealm(String entityRef) throws PermissionException {
+		Reference ref = getSiteReference(entityRef);
+		if (canRemoveAdminRealm(entityRef)) {
+			dao().delete(entityRef);
+			eventTrackingService().post(eventTrackingService().newEvent(ADMIN_REALM_CHANGE, entityRef, true));
 		} else {
 			throw new PermissionException(null,null,null);
 		}

--- a/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
+++ b/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
@@ -3943,7 +3943,7 @@ public class SiteAction extends PagedResourceActionII {
 			boolean canRemoveAdmin = DevolvedSakaiSecurity.canRemoveAdminRealm(site.getReference());
 			List adminSites = new ArrayList();
 			if (canRemoveAdmin) {
-				adminSites.add(new AdminRealm("unmanged", getAdminReferenceName(null)));
+				adminSites.add(new AdminRealm("unmanaged", getAdminReferenceName(null)));
 			}
 			List<Entity> adminRealms = DevolvedSakaiSecurity.getAvailableAdminRealms(site.getReference());
 			Collections.sort(adminRealms, devolvedAdminComparator);


### PR DESCRIPTION
When a admin site is changed on a site the property on the site is updated. Also when a title of an admin site is changed all the sites managed by that site are updated if they don’t have the property set correctly.

Also fixed a bug where unmanaging a site would result in it being managed by a non-existent site. We also fire an event when a site becomes unmanaged.