### PR TITLE
WL-4671 Fix multiple LTI Admin sites NPE

### DIFF
--- a/basiclti/basiclti-impl/src/java/org/sakaiproject/lti/impl/BaseLTIService.java
+++ b/basiclti/basiclti-impl/src/java/org/sakaiproject/lti/impl/BaseLTIService.java
@@ -359,7 +359,7 @@ public abstract class BaseLTIService implements LTIService {
 			throw new java.lang.RuntimeException("isAdmin() requires non-null siteId");
 		}
 		String[] adminSites = serverConfigurationService.getStrings("basiclti.admin.sites");
-		if (adminSites.length == 0) {
+		if (adminSites == null || adminSites.length == 0) {
 			adminSites = new String[]{"!admin"};
 		}
 		if (!Arrays.asList(adminSites).contains(siteId)) return false;

--- a/docker/sakai/placeholder.properties
+++ b/docker/sakai/placeholder.properties
@@ -818,6 +818,9 @@ lessonbuilder.folder.hidden=true
 # Allow LTI tools to post outcomes back to the gradebook. WL-4077
 basiclti.outcomes.enabled=true 
 
+# Allow the external tool to work in admin mode in more than just the admin workspace.
+basiclti.admin.sites=!admin,!lti-admin
+
 # Cache settings for LDAP course owners
 memory.uk.ac.ox.oucs.vle.UniquePathHandler.courseOwnersCache=maxElementsInMemory=10,timeToLiveSeconds=3600,timeToIdleSeconds=3600
 


### PR DESCRIPTION
When the config wasn't defined the LTI service would throw a NullPointerException, we catch this case now and handle it gracefully.