### PR TITLE
WL-4504 Fix for NPE when updating admin sites.

### DIFF
--- a/jobscheduler/scheduler-component-shared/src/java/org/sakaiproject/component/app/scheduler/jobs/EventTriggerJob.java
+++ b/jobscheduler/scheduler-component-shared/src/java/org/sakaiproject/component/app/scheduler/jobs/EventTriggerJob.java
@@ -31,13 +31,18 @@ public class EventTriggerJob implements Job {
     @Override
     public void execute(JobExecutionContext context) throws JobExecutionException {
         String siteType = context.getMergedJobDataMap().getString("type");
-        if (siteType == null) {
+        if (siteType == null || siteType.isEmpty()) {
             log.warn("You need to set a site type");
+            return;
+        }
+        String eventType = context.getMergedJobDataMap().getString("event");
+        if (eventType == null || eventType.isEmpty()) {
+            log.warn("You need to set a event type");
             return;
         }
 
         for (Site site: siteService.getSites(SiteService.SelectionType.ANY, siteType, null, null,SiteService.SortType.NONE, null)) {
-            Event event = eventTrackingService.newEvent(SiteService.SECURE_UPDATE_SITE, site.getReference(), true);
+            Event event = eventTrackingService.newEvent(eventType, site.getReference(), true);
             eventTrackingService.post(event);
         }
     }

--- a/jobscheduler/scheduler-component-shared/src/java/org/sakaiproject/component/app/scheduler/jobs/EventTriggerJob.properties
+++ b/jobscheduler/scheduler-component-shared/src/java/org/sakaiproject/component/app/scheduler/jobs/EventTriggerJob.properties
@@ -1,1 +1,2 @@
 site.type=Site Type
+event.type=Event

--- a/jobscheduler/scheduler-component/src/webapp/WEB-INF/event-trigger.xml
+++ b/jobscheduler/scheduler-component/src/webapp/WEB-INF/event-trigger.xml
@@ -29,6 +29,12 @@
                     <property name="descriptionResourceKey" value="site.type"/>
                     <property name="defaultValue" value="project"/>
                 </bean>
+                <bean class="org.sakaiproject.component.app.scheduler.jobs.SpringConfigurableJobProperty">
+                    <property name="required" value="true"/>
+                    <property name="labelResourceKey" value="event"/>
+                    <property name="descriptionResourceKey" value="event.type"/>
+                    <property name="defaultValue" value="site.upd"/>
+                </bean>
             </set>
         </property>
         <property name="schedulerManager">

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/authz/impl/DepartmentSiteAdvisor.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/authz/impl/DepartmentSiteAdvisor.java
@@ -133,7 +133,8 @@ public class DepartmentSiteAdvisor implements SiteAdvisor, Observer {
                 if (entity instanceof Site) {
                     Site managedSite = (Site) entity;
                     ResourcePropertiesEdit properties = managedSite.getPropertiesEdit();
-                    if (!properties.getProperty(siteProperty).equals(site.getTitle())) {
+                    String property = properties.getProperty(siteProperty);
+                    if (property == null || !property.equals(site.getTitle())) {
                         properties.addProperty(siteProperty, site.getTitle());
                         try {
                             siteService.save(managedSite);

--- a/kernel/kernel-impl/src/test/java/org/sakaiproject/authz/impl/DepartmentSiteAdvisorTest.java
+++ b/kernel/kernel-impl/src/test/java/org/sakaiproject/authz/impl/DepartmentSiteAdvisorTest.java
@@ -1,0 +1,173 @@
+package org.sakaiproject.authz.impl;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.sakaiproject.entity.api.EntityManager;
+import org.sakaiproject.entity.api.Reference;
+import org.sakaiproject.entity.api.ResourceProperties;
+import org.sakaiproject.entity.api.ResourcePropertiesEdit;
+import org.sakaiproject.event.api.Event;
+import org.sakaiproject.event.api.EventTrackingService;
+import org.sakaiproject.exception.IdUnusedException;
+import org.sakaiproject.exception.PermissionException;
+import org.sakaiproject.site.api.Site;
+import org.sakaiproject.site.api.SiteService;
+
+import java.util.Arrays;
+
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests the department site advisor.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class DepartmentSiteAdvisorTest {
+
+    private DepartmentSiteAdvisor advisor;
+
+    @Mock
+    private DevolvedSakaiSecurityImpl devolvedSakaiSecurity;
+    @Mock
+    private SiteService siteService;
+    @Mock
+    private EntityManager entityManager;
+    @Mock
+    private EventTrackingService eventTrackingService;
+
+    @Before
+    public void setUp() {
+        advisor = new DepartmentSiteAdvisor();
+        advisor.setDevolvedSakaiSecurity(devolvedSakaiSecurity);
+        advisor.setSiteService(siteService);
+        advisor.setEntityManager(entityManager);
+        advisor.setEventTrackingService(eventTrackingService);
+        advisor.setSiteProperty("property");
+
+    }
+
+    @Test
+    public void testInit() {
+        advisor.init();
+        verify(siteService).addSiteAdvisor(advisor);
+        verify(eventTrackingService).addLocalObserver(advisor);
+    }
+
+    // Checks that when an admin site is changed on a site the new title is set.
+    @Test
+    public void testAdminChangeSite() throws PermissionException, IdUnusedException {
+        Event event = mock(Event.class);
+        when(event.getEvent()).thenReturn(DevolvedSakaiSecurityImpl.ADMIN_REALM_CHANGE);
+        when(event.getResource()).thenReturn("/site/id");
+        Site site = mock(Site.class);
+        when(site.getReference()).thenReturn("/site/id");
+        ResourceProperties properties = mock(ResourceProperties.class);
+        when(site.getProperties()).thenReturn(properties);
+
+        Reference reference = mock(Reference.class);
+        when(reference.getEntity()).thenReturn(site);
+        when(entityManager.newReference("/site/id")).thenReturn(reference);
+
+        when(devolvedSakaiSecurity.getAdminRealm("/site/id")).thenReturn("/site/admin");
+        Reference adminReference = mock(Reference.class);
+        when(entityManager.newReference("/site/admin")).thenReturn(adminReference);
+        Site adminSite = mock(Site.class);
+        when(adminSite.getTitle()).thenReturn("Admin Title");
+        when(adminReference.getEntity()).thenReturn(adminSite);
+
+        advisor.update(null, event);
+
+        verify(properties).addProperty("property", "Admin Title");
+        verify(siteService).save(site);
+    }
+
+    // Checks that when an admin site is removed on a site the old title is remove.
+    @Test
+    public void testAdminChangeNone() throws PermissionException, IdUnusedException {
+        Event event = mock(Event.class);
+        when(event.getEvent()).thenReturn(DevolvedSakaiSecurityImpl.ADMIN_REALM_CHANGE);
+        when(event.getResource()).thenReturn("/site/id");
+        Site site = mock(Site.class);
+        when(site.getReference()).thenReturn("/site/id");
+        ResourceProperties properties = mock(ResourceProperties.class);
+        when(site.getProperties()).thenReturn(properties);
+
+        Reference reference = mock(Reference.class);
+        when(reference.getEntity()).thenReturn(site);
+        when(entityManager.newReference("/site/id")).thenReturn(reference);
+
+        when(devolvedSakaiSecurity.getAdminRealm("/site/id")).thenReturn(null);
+        Reference adminReference = mock(Reference.class);
+        when(entityManager.newReference("/site/admin")).thenReturn(adminReference);
+        Site adminSite = mock(Site.class);
+        when(adminSite.getTitle()).thenReturn("Admin Title");
+        when(adminReference.getEntity()).thenReturn(adminSite);
+
+        advisor.update(null, event);
+
+        verify(properties).removeProperty("property");
+        verify(siteService).save(site);
+    }
+
+    // Checks when an admin site's title is set the managed sites are updated.
+    @Test
+    public void testAdminUpdate() throws PermissionException, IdUnusedException {
+        Event event = mock(Event.class);
+        when(event.getEvent()).thenReturn(SiteService.SECURE_UPDATE_SITE);
+        when(event.getResource()).thenReturn("/site/admin");
+        Reference adminReference = mock(Reference.class);
+        Site adminSite = mock(Site.class);
+        when(entityManager.newReference("/site/admin")).thenReturn(adminReference);
+        when(adminReference.getEntity()).thenReturn(adminSite);
+        when(adminSite.getReference()).thenReturn("/site/admin");
+        when(adminSite.getType()).thenReturn("admin");
+        when(adminSite.getTitle()).thenReturn("Admin Title");
+
+        Site site = mock(Site.class);
+        ResourcePropertiesEdit properties = mock(ResourcePropertiesEdit.class);
+        when(site.getPropertiesEdit()).thenReturn(properties);
+
+        when(devolvedSakaiSecurity.getAdminSiteType()).thenReturn("admin");
+        when(devolvedSakaiSecurity.findUsesOfAdmin("/site/admin")).thenReturn(Arrays.asList(site));
+
+        advisor.update(null, event);
+
+        verify(properties).addProperty("property", "Admin Title");
+        verify(siteService).save(site);
+    }
+
+    // Checks when an admin site's title is changed the managed sites are updated.
+    @Test
+    public void testAdminUpdateChange() throws PermissionException, IdUnusedException {
+        Event event = mock(Event.class);
+        when(event.getEvent()).thenReturn(SiteService.SECURE_UPDATE_SITE);
+        when(event.getResource()).thenReturn("/site/admin");
+        Reference adminReference = mock(Reference.class);
+        Site adminSite = mock(Site.class);
+        when(entityManager.newReference("/site/admin")).thenReturn(adminReference);
+        when(adminReference.getEntity()).thenReturn(adminSite);
+        when(adminSite.getReference()).thenReturn("/site/admin");
+        when(adminSite.getType()).thenReturn("admin");
+        when(adminSite.getTitle()).thenReturn("Admin Title");
+
+        Site site = mock(Site.class);
+        ResourcePropertiesEdit properties = mock(ResourcePropertiesEdit.class);
+        when(site.getPropertiesEdit()).thenReturn(properties);
+
+        when(devolvedSakaiSecurity.getAdminSiteType()).thenReturn("admin");
+        when(devolvedSakaiSecurity.findUsesOfAdmin("/site/admin")).thenReturn(Arrays.asList(site));
+
+        // Give site an old title.
+        when(properties.getProperty("property")).thenReturn("Old Admin Title");
+
+        advisor.update(null, event);
+
+        verify(properties).addProperty("property", "Admin Title");
+        verify(siteService).save(site);
+    }
+
+
+}


### PR DESCRIPTION
Because all the sites didn’t have an existing property set when attempting to generate an admin site update event the event listener failed with a NPE. This changes means that it works correctly even if you don’t already have a admin site property set.

I’ve also updated the backfill job so you can specify the event as this allows you to generate the admin change event across all project sites which would have also allowed the update to work, but the currently deployed version doesn’t have this so we couldn’t.