### PR TITLE
WL-4842 Include the contact in the display page.

### DIFF
--- a/shoal/tool/src/java/uk/ac/ox/it/shoal/pages/DisplayPage.java
+++ b/shoal/tool/src/java/uk/ac/ox/it/shoal/pages/DisplayPage.java
@@ -85,6 +85,8 @@ public class DisplayPage extends SakaiPage {
             addIfNotNull(metadata, type);
             Metadata author = newMetadata(document, "author", "author", "field.label.author");
             addIfNotNull(metadata, author);
+            Metadata contact = newMetadata(document, "contact", "contact", "field.label.contact");
+            addIfNotNull(metadata, contact);
             Metadata added = newMetadata(document, "added", null, "field.label.added");
             addIfNotNull(metadata, added);
             Metadata permission = newMetadata(document, "permission", null, "field.label.permission");


### PR DESCRIPTION
When displaying the full details of an item we should include the contact details for the item.