### PR TITLE
WL-4839 WL-4840: announcements item in listing is all squashed up

### DIFF
--- a/lessonbuilder/tool/src/webapp/css/Simplepagetool.css
+++ b/lessonbuilder/tool/src/webapp/css/Simplepagetool.css
@@ -687,7 +687,7 @@ padding: 10px 15px 0 15px
  color:#000;
  font-weight: normal;
 }
-.forumSummaryList{
+.forumSummaryList, .announcementSummaryList{
  list-style: none;
  padding: 0 15px;
  font-family: 'Segoe UI', Segoe, Tahoma, Helvetica, Arial, sans-serif;
@@ -702,7 +702,7 @@ padding: 10px 15px 0 15px
     float:left;
 }
 
-.forumSummaryItem{
+.forumSummaryItem, .announcementSummaryItem{
  margin-bottom: 10px;
 }
 

--- a/lessonbuilder/tool/src/webapp/js/announcements.js
+++ b/lessonbuilder/tool/src/webapp/js/announcements.js
@@ -29,6 +29,7 @@ function showAnnouncements(url, tool_href, number, announcementsDiv){
 					text_for_announcements += '<p>'+msg("simplepage.announcements-no-message")+'</p>';
 				}
 				else {
+					text_for_announcements += '<ul class="announcementSummaryList">';
 					$(data["announcement_collection"]).each(function(){
 						//create a new javascript Date object based on the timestamp
 						date = new Date(this["createdOn"]);
@@ -36,14 +37,15 @@ function showAnnouncements(url, tool_href, number, announcementsDiv){
 						var min = date.getMinutes() < 10 ? '0' + date.getMinutes() : date.getMinutes();
 						//using javascript's toLocaleDateString() to include user's locale and local time zone
 						date_time = hour +":"+min+ " " + date.toLocaleDateString();
-						text_for_announcements += '<div class="itemDiv">';
+						text_for_announcements += '<li class="itemDiv announcementSummaryItem">';
 						var href = tool_href + this["announcementId"]+"&sakai_action=doShowmetadata";
 						var entityTitle = this["entityTitle"].replace(/&/g, '&amp;').replace(/>/g, '&gt;').replace(/</g, '&lt;').replace(/"/g, '&quot;');
 						var createdByDisplayName = this["createdByDisplayName"].replace(/&/g, '&amp;').replace(/>/g, '&gt;').replace(/</g, '&lt;').replace(/"/g, '&quot;');
-						text_for_announcements += '<div class="itemTitle"><a href="'+href+'" target="_top">'+ entityTitle +'</a> by '+ createdByDisplayName +'</div>';
+						text_for_announcements += '<div><a href="'+href+'" target="_top">'+ entityTitle +'</a> by '+ createdByDisplayName +'</div>';
 						text_for_announcements += '<div class="itemDate">'+date_time+'</div>';
-						text_for_announcements += '</div>';
+						text_for_announcements += '</li>';
 					});
+					text_for_announcements += '</ul>';
 				}
 				announcementsDiv.html(text_for_announcements);
 			},


### PR DESCRIPTION
This also fixes WL-4840 - the announcement border issue.

The basic idea here is to try to make the Announcements widgets look and feel the same as the Forums widget, hence a css class with the same stylings, and converting divs to list items.  The actual thing that fixes the squashing up of the lines is removing the itemTitle class (which enforces a fixedline height) from the HTML.  