### PR TITLE
WL-4504 Fix for permission denied errors.

### DIFF
--- a/jobscheduler/scheduler-component/src/webapp/WEB-INF/event-trigger.xml
+++ b/jobscheduler/scheduler-component/src/webapp/WEB-INF/event-trigger.xml
@@ -8,6 +8,7 @@
           class="org.sakaiproject.component.app.scheduler.jobs.EventTriggerJob">
         <property name="siteService" ref="org.sakaiproject.site.api.SiteService"/>
         <property name="eventTrackingService" ref="org.sakaiproject.event.api.EventTrackingService"/>
+        <property name="sessionManager" ref="org.sakaiproject.session.api.SessionManager"/>
     </bean>
 
     <bean id="org.sakaiproject.api.app.scheduler.JobBeanWrapper.BackFillToolJob"


### PR DESCRIPTION
Make sure we can save the site because although normally you could save all the managed sites, when running though the quartz scheduler you can’t.