### PR TITLE
WL-4829 Don't use a special admin site for LTI

### DIFF
--- a/docker/sakai/placeholder.properties
+++ b/docker/sakai/placeholder.properties
@@ -823,7 +823,7 @@ lessonbuilder.folder.hidden=true
 basiclti.outcomes.enabled=true 
 
 # Allow the external tool to work in admin mode in more than just the admin workspace.
-basiclti.admin.sites=!admin,!lti-admin
+basiclti.admin.sites=!admin,lti-admin
 
 # Set our department.
 basiclti.tool.site.attribution.key=department


### PR DESCRIPTION
This appeared to cause the LTI admin site to not appear in the My Sites
dropdown.