### PR TITLE
WL-4852 Use fluid columns instead of fixed ones.

### DIFF
--- a/shoal/tool/src/java/uk/ac/ox/it/shoal/pages/DisplayPage.html
+++ b/shoal/tool/src/java/uk/ac/ox/it/shoal/pages/DisplayPage.html
@@ -13,7 +13,7 @@
 </head>
 <body>
 <wicket:extend>
-    <div class="container display">
+    <div class="container-fluid display">
         <div class="row">
             <div class="col-sm-5 col-md-4 back">
                 <a href="javascript:history.go(-1)">[Go Back]</a>


### PR DESCRIPTION
This means that the tool menu on the left of the page doesn’t push the columns over the edge of the page. It’s still adjusting down to smaller sizes as the viewport gets smaller.