### PR TITLE
WL-4815: Manually creating citations causes duplicate sections

### DIFF
--- a/citations/citations-impl/impl/src/java/org/sakaiproject/citation/impl/DbCitationService.java
+++ b/citations/citations-impl/impl/src/java/org/sakaiproject/citation/impl/DbCitationService.java
@@ -381,6 +381,8 @@ public class DbCitationService extends BaseCitationService
 		*/
 		protected void commitCitationCollectionOrder(CitationCollectionOrder citationCollectionOrder)
 		{
+			deleteCitationCollectionOrder(citationCollectionOrder);
+
 			String orderStatement = "insert into " + m_collectionOrderTableName + " (COLLECTION_ID, CITATION_ID, LOCATION, SECTION_TYPE, VALUE) VALUES(?,?,?,?,?)";
 
 			Object[] orderFields = new Object[5];
@@ -954,6 +956,22 @@ public class DbCitationService extends BaseCitationService
 
 			boolean ok = m_sqlService.dbWrite(statement, fields);
         }
+
+		/* (non-Javadoc)
+		* @see org.sakaiproject.citation.impl.BaseCitationService.Storage#deleteCitationCollectionOrder(rg.sakaiproject.citation.api.CitationCollectionOrder))
+		*/
+		protected void deleteCitationCollectionOrder(CitationCollectionOrder citationCollectionOrder)
+		{
+			String statement = "delete from " + m_collectionOrderTableName + " where (" + m_collectionTableId + " = ? AND " +
+					"LOCATION = ? )";
+
+			Object fields[] = new Object[2];
+			fields[0] = citationCollectionOrder.getCollectionId();
+			fields[1] = citationCollectionOrder.getLocation();
+
+			boolean ok = m_sqlService.dbWrite(statement, fields);
+		}
+
 
 		/* (non-Javadoc)
          * @see org.sakaiproject.citation.impl.BaseCitationService.Storage#removeCollection(org.sakaiproject.citation.api.CitationCollection)


### PR DESCRIPTION
What is happening during the test plan is that at some point a copy is made of the existing citation_collection.  During this copy, a new copied citation is created and saved to the collection, and the old is deleted.  But when it copies across the citationcollectionorders, it was not deleting them , hence the duplicate sections. The fix is to put in a bit where it deletes them to mirror what is happening with citations. 