### PR TITLE
WL-4874 Don’t overflow outside the main page.

### DIFF
--- a/shoal/tool/src/java/uk/ac/ox/it/shoal/pages/SimpleSearchPage$EntryPanel.html
+++ b/shoal/tool/src/java/uk/ac/ox/it/shoal/pages/SimpleSearchPage$EntryPanel.html
@@ -17,7 +17,7 @@
 <body>
 
 <wicket:panel>
-    <div class="container">
+    <div class="container-fluid">
         <div class="row">
             <div class="col-md-12">
                 <h3>Discover Learning Resources</h3>


### PR DESCRIPTION
In the shoal browser just fit into the space we’re given. This prevents horizontal scroll bars.