### PR TITLE
WL-4858 Add checkbox to hide an item in search.

### DIFF
--- a/shoal/api/src/java/uk/ac/ox/it/shoal/model/TeachingItem.java
+++ b/shoal/api/src/java/uk/ac/ox/it/shoal/model/TeachingItem.java
@@ -68,4 +68,9 @@ public interface TeachingItem {
     String getUrl();
 
     void setUrl(String url);
+
+    boolean isHidden();
+
+    void setHidden(boolean hidden);
+
 }

--- a/shoal/api/src/java/uk/ac/ox/it/shoal/model/TeachingItemModel.java
+++ b/shoal/api/src/java/uk/ac/ox/it/shoal/model/TeachingItemModel.java
@@ -24,6 +24,7 @@ public class TeachingItemModel implements Serializable, TeachingItem {
     private String thumbnail;
     private String license;
     private String url;
+    private boolean hidden;
 
     @Override
     public String getId() {
@@ -173,5 +174,15 @@ public class TeachingItemModel implements Serializable, TeachingItem {
     @Override
     public void setUrl(String url) {
         this.url = url;
+    }
+
+    @Override
+    public boolean isHidden() {
+        return hidden;
+    }
+
+    @Override
+    public void setHidden(boolean hidden) {
+        this.hidden = hidden;
     }
 }

--- a/shoal/impl/src/java/uk/ac/ox/it/shoal/logic/SakaiProxyImpl.java
+++ b/shoal/impl/src/java/uk/ac/ox/it/shoal/logic/SakaiProxyImpl.java
@@ -194,6 +194,9 @@ public class SakaiProxyImpl implements SakaiProxy {
         teachingItem.setThumbnail(properties.getProperty(key("thumbnail")));
         teachingItem.setLicense(properties.getProperty(key("license")));
         teachingItem.setUrl(properties.getProperty(key("url")));
+        // Default to false (not hidden)
+        String hidden = properties.getProperty(key("hidden"));
+        teachingItem.setHidden(Boolean.valueOf(hidden));
 
         return teachingItem;
     }
@@ -232,6 +235,7 @@ public class SakaiProxyImpl implements SakaiProxy {
                 properties.addProperty(key("thumbnail"), model.getThumbnail());
                 properties.addProperty(key("license"), model.getLicense());
                 properties.addProperty(key("url"), model.getUrl());
+                properties.addProperty(key("hidden"), Boolean.toString(model.isHidden()));
 
                 siteService.save(site);
 

--- a/shoal/tool/src/java/uk/ac/ox/it/shoal/EditApplication.properties
+++ b/shoal/tool/src/java/uk/ac/ox/it/shoal/EditApplication.properties
@@ -29,6 +29,7 @@ author.help = The person or people who created this activity
 contact.help = The name and/or email address of the person to contact regarding re-use (Optional)
 permission.help = Describe the use rights of the activity.  Can the whole activity or elements of it be used as-is or adapted by other Oxford University staff or students?  How might someone gain permission to use the activity?  What fee options are available for re-use?
 thumbnail.help = Add a screenshot which illustrates the activity 200x200 pixels.
+hidden.help = If checked then this item isn't findable by end users through search.
 
 
 

--- a/shoal/tool/src/java/uk/ac/ox/it/shoal/pages/EditPage.html
+++ b/shoal/tool/src/java/uk/ac/ox/it/shoal/pages/EditPage.html
@@ -155,6 +155,15 @@
                         <input type="file" class="form-control" wicket:id="thumbnail"/>
                     </div>
                 </div>
+                <div class="form-group" wicket:id="hidden-group">
+                    <div class="col-sm-2 control-label">
+                        <label wicket:id="hidden-label">Hidden</label>
+                        <span class="glyphicon glyphicon-question-sign" title="Hidden" wicket:message="title:hidden.help"></span>
+                    </div>
+                    <div class="col-sm-10">
+                        <input type="checkbox" class="form-control" wicket:id="hidden"/>
+                    </div>
+                </div>
                 <div class="form-group">
                     <div class="col-sm-offset-2 col-sm-10">
                         <button type="submit" wicket:id="save" class="btn btn-primary">Save</button>

--- a/shoal/tool/src/java/uk/ac/ox/it/shoal/pages/EditPage.java
+++ b/shoal/tool/src/java/uk/ac/ox/it/shoal/pages/EditPage.java
@@ -151,6 +151,14 @@ public class EditPage extends SakaiPage {
         Image image = new Image("thumbnail-current", icon);
         thumbnailGroup.add(image);
 
+        WebMarkupContainer hiddenGroup = new WebMarkupContainer("hidden-group");
+        CheckBox hidden = new CheckBox("hidden");
+        permission.add(new PropertyValidator<>());
+        FormComponentLabel hiddenLabel = new FormComponentLabel("hidden-label", hidden);
+        hiddenGroup.add(hiddenLabel);
+        hiddenGroup.add(hidden);
+        hiddenGroup.add(new ErrorBehaviour(hidden));
+
         Button submit = new Button("save");
 
         Form<TeachingItem> form = new Form<TeachingItem>("item") {
@@ -186,6 +194,7 @@ public class EditPage extends SakaiPage {
         form.add(contactGroup);
         form.add(permissionGroup);
         form.add(thumbnailGroup);
+        form.add(hiddenGroup);
         form.add(submit);
 
     }

--- a/shoal/utils/src/java/uk/ac/ox/it/shoal/model/ValidatedTeachingItem.java
+++ b/shoal/utils/src/java/uk/ac/ox/it/shoal/model/ValidatedTeachingItem.java
@@ -153,4 +153,12 @@ public class ValidatedTeachingItem implements TeachingItem, Serializable {
         item.setUrl(url);
     }
 
+    public boolean isHidden() {
+        return item.isHidden();
+    }
+
+    public void setHidden(boolean hidden) {
+        item.setHidden(hidden);
+    }
+
 }


### PR DESCRIPTION
No schema changes and it just means hidden items are removed from the index. By default everything is unhidden so existing items won’t be hidden unless someone manually makes them.