### PR TITLE
WL-4861 Sort by updated instead of added.

### DIFF
--- a/shoal/tool/src/java/uk/ac/ox/it/shoal/SearchApplication.properties
+++ b/shoal/tool/src/java/uk/ac/ox/it/shoal/SearchApplication.properties
@@ -3,6 +3,7 @@ link.search = Text Search
 
 Order.label = Sort by
 Order.added = Date Added
+Order.updated = Date Updated
 Order.score = Relevance
 
 page.preview = View
@@ -18,6 +19,7 @@ field.label.purpose = Educational Use
 field.label.interactivity = Interactivity
 field.label.type = Type
 field.label.added = Added
+field.label.updated = Last Updated
 field.label.permission = Re-use
 
 no.results.found = No results found.

--- a/shoal/tool/src/java/uk/ac/ox/it/shoal/pages/DisplayPage.java
+++ b/shoal/tool/src/java/uk/ac/ox/it/shoal/pages/DisplayPage.java
@@ -90,7 +90,7 @@ public class DisplayPage extends SakaiPage {
             addIfNotNull(metadata, author);
             Metadata contact = newMetadata(document, "contact", "contact", "field.label.contact");
             addIfNotNull(metadata, contact);
-            Metadata added = newMetadata(document, "added", null, "field.label.added");
+            Metadata added = newMetadata(document, "updated", null, "field.label.updated");
             addIfNotNull(metadata, added);
             Metadata permission = newMetadata(document, "permission", null, "field.label.permission");
             addIfNotNull(metadata, permission);

--- a/shoal/tool/src/java/uk/ac/ox/it/shoal/pages/Order.java
+++ b/shoal/tool/src/java/uk/ac/ox/it/shoal/pages/Order.java
@@ -4,5 +4,5 @@ package uk.ac.ox.it.shoal.pages;
  * Created by buckett on 12/12/2016.
  */
 public enum Order {
-    score, added
+    score, updated
 }

--- a/shoal/tool/src/java/uk/ac/ox/it/shoal/pages/SolrProvider.java
+++ b/shoal/tool/src/java/uk/ac/ox/it/shoal/pages/SolrProvider.java
@@ -45,12 +45,12 @@ public class SolrProvider implements AdvancedIDataProvider<SolrDocument>
 
 		// Setup the default order to sort thing by.
 		List<Tuple<String,ORDER>> order = new ArrayList<>();
-		order.add(new Tuple<>("added", ORDER.desc));
+		order.add(new Tuple<>("score", ORDER.desc));
 		DEFAULT_ORDER = Collections.unmodifiableList(order);
 
 		// Setup order by.
 		orders = new ArrayList<>();
-		orders.add(new Tuple<>("added", ORDER.desc));
+		orders.add(new Tuple<>("updated", ORDER.desc));
 		orders.add(new Tuple<>("score", ORDER.desc));
 	}
 
@@ -101,7 +101,7 @@ public class SolrProvider implements AdvancedIDataProvider<SolrDocument>
 
 	public void setSort(List<Tuple<String,ORDER>> order) {
 		// Play it safe and take a copy.
-		this.order = new ArrayList<Tuple<String,ORDER>>(order);
+		this.order = new ArrayList<>(order);
 	}
 
 	public void setFilters(String[] filters) {


### PR DESCRIPTION
This is partly because when searching by added all the sites have the same date due to cloning the original site. We also display this updated date instead of the added date in the display page.