### PR TITLE
WL-4880 Re-order facets and harmonise terms.

### DIFF
--- a/shoal/tool/src/java/uk/ac/ox/it/shoal/EditApplication.java
+++ b/shoal/tool/src/java/uk/ac/ox/it/shoal/EditApplication.java
@@ -4,6 +4,7 @@ import org.apache.wicket.MetaDataKey;
 import org.apache.wicket.Page;
 import org.apache.wicket.bean.validation.BeanValidationConfiguration;
 import org.apache.wicket.resource.loader.ClassStringResourceLoader;
+import org.apache.wicket.resource.loader.PackageStringResourceLoader;
 import uk.ac.ox.it.shoal.pages.EditPage;
 
 import java.util.ArrayList;
@@ -38,6 +39,7 @@ public class EditApplication extends SakaiApplication {
         mountPage("/", EditPage.class);
         mountPage("/edit", EditPage.class);
         getResourceSettings().getStringResourceLoaders().add(new ClassStringResourceLoader(EditApplication.class));
+        getResourceSettings().getStringResourceLoaders().add(new PackageStringResourceLoader()) ;
         setMetaData(SUBJECT, readFile("/subjects.txt"));
         setMetaData(LEVEL, readFile("/levels.txt"));
         setMetaData(PURPOSE, readFile("/purposes.txt"));

--- a/shoal/tool/src/java/uk/ac/ox/it/shoal/EditApplication.properties
+++ b/shoal/tool/src/java/uk/ac/ox/it/shoal/EditApplication.properties
@@ -1,22 +1,4 @@
-page.title = Search Page
-link.search = Text Search
-
-Order.label = Sort by
-Order.added = Date Added
-Order.score = Relevance
-
-page.preview = Preview
-
-year.nullValid = All Years
-
-field.label.author = Author
-field.label.subject = Subject
-field.label.level = Level
-field.label.purpose = Educational Use
-field.label.interactivity = Interactivity
-field.label.type = Type
-
-field.label.added = Added
+page.title = Edit Page
 
 title.help = A concise title that indicates the type of learning activity as well as the subject content, to encourage people to view your work
 description.help = Describe the overall pedagogical goal of the learning activity: what is the specific subject and what should students be able to do after participating; what were your aims in developing this activity, what motivated your choice of digital tool(s), and how did you and/or the students' benefit from the experience?
@@ -32,12 +14,7 @@ thumbnail.help = Add a screenshot which illustrates the activity 200x200 pixels.
 hidden.help = If checked then this item isn't findable by end users through search.
 
 
-
-no.results.found = No results found.
-
 save.ok = Update saved.
 save.image = Thumbnail updated.
 
 save.image.problem = Problem saving the image, please try again.
-
-facet.too.many = Too many item found to filter by, try adding some more terms to the search, or filtering by something else first.

--- a/shoal/tool/src/java/uk/ac/ox/it/shoal/SearchApplication.java
+++ b/shoal/tool/src/java/uk/ac/ox/it/shoal/SearchApplication.java
@@ -7,6 +7,7 @@ import org.apache.wicket.request.mapper.parameter.PageParameters;
 import org.apache.wicket.request.resource.SharedResourceReference;
 import org.apache.wicket.resource.FileSystemResource;
 import org.apache.wicket.resource.loader.ClassStringResourceLoader;
+import org.apache.wicket.resource.loader.PackageStringResourceLoader;
 import uk.ac.ox.it.shoal.pages.DisplayPage;
 import uk.ac.ox.it.shoal.pages.SimpleSearchPage;
 
@@ -31,6 +32,7 @@ public class SearchApplication extends SakaiApplication {
         mountPage("/display", DisplayPage.class);
 
         getResourceSettings().getStringResourceLoaders().add(new ClassStringResourceLoader(SearchApplication.class));
+        getResourceSettings().getStringResourceLoaders().add(new PackageStringResourceLoader()) ;
 
         getSharedResources().add("thumbnails", new FolderContentResource(Paths.get(System.getProperty("java.io.tmpdir"))));
         mountResource("/thumbnail/${filename}", new SharedResourceReference("thumbnails"));

--- a/shoal/tool/src/java/uk/ac/ox/it/shoal/SearchApplication.properties
+++ b/shoal/tool/src/java/uk/ac/ox/it/shoal/SearchApplication.properties
@@ -8,20 +8,6 @@ Order.score = Relevance
 
 page.preview = View
 
-year.nullValid = All Years
-
-field.label.license = License
-field.label.author = Author
-field.label.contact = Contact
-field.label.subject = Subject
-field.label.level = Level
-field.label.purpose = Educational Use
-field.label.interactivity = Interactivity
-field.label.type = Type
-field.label.added = Added
-field.label.updated = Last Updated
-field.label.permission = Re-use
-
 no.results.found = No results found.
 
 facet.too.many = Too many item found to filter by, try adding some more terms to the search, or filtering by something else first.

--- a/shoal/tool/src/java/uk/ac/ox/it/shoal/pages/EditPage.html
+++ b/shoal/tool/src/java/uk/ac/ox/it/shoal/pages/EditPage.html
@@ -32,7 +32,9 @@
             <form wicket:id="item" class="form-horizontal">
                 <div class="form-group" wicket:id="title-group">
                     <div class="col-sm-2 control-label">
-                        <label wicket:id="title-label">Title</label>
+                        <label wicket:id="title-label">
+                            <wicket:message key="field.label.title">Title</wicket:message>
+                        </label>
                         <span class="glyphicon glyphicon-question-sign" title="Title"
                               wicket:message="title:title.help"></span>
                     </div>
@@ -42,7 +44,9 @@
                 </div>
                 <div class="form-group" wicket:id="description-group">
                     <div class="col-sm-2 control-label">
-                        <label wicket:id="description-label">Description</label>
+                        <label wicket:id="description-label">
+                            <wicket:message key="field.label.description">Description</wicket:message>
+                        </label>
                         <span class="glyphicon glyphicon-question-sign" title="Description"
                               wicket:message="title:description.help"></span>
                     </div>
@@ -52,7 +56,9 @@
                 </div>
                 <div class="form-group" wicket:id="subject-group">
                     <div class="col-sm-2 control-label">
-                        <label wicket:id="subject-label">Subject</label>
+                        <label wicket:id="subject-label">
+                            <wicket:message key="field.label.subject">Subject</wicket:message>
+                        </label>
                         <span class="glyphicon glyphicon-question-sign" title="Subject"
                               wicket:message="title:subject.help"></span>
                     </div>
@@ -65,7 +71,9 @@
                 </div>
                 <div class="form-group" wicket:id="interactivity-group">
                     <div class="col-sm-2 control-label">
-                        <label wicket:id="interactivity-label">Interactivity</label>
+                        <label wicket:id="interactivity-label">
+                            <wicket:message key="field.label.interactivity">Interactivity</wicket:message>
+                        </label>
                         <span class="glyphicon glyphicon-question-sign" title="Interactivity"
                               wicket:message="title:interactivity.help"></span>
                     </div>
@@ -78,7 +86,9 @@
                 </div>
                 <div class="form-group" wicket:id="level-group">
                     <div class="col-sm-2 control-label">
-                        <label wicket:id="level-label">Level</label>
+                        <label wicket:id="level-label">
+                            <wicket:message key="field.label.level">Level</wicket:message>
+                        </label>
                         <span class="glyphicon glyphicon-question-sign" title="Level"
                               wicket:message="title:level.help"></span>
                     </div>
@@ -91,7 +101,9 @@
                 </div>
                 <div class="form-group" wicket:id="purpose-group">
                     <div class="col-sm-2 control-label">
-                        <label wicket:id="purpose-label">Purpose</label>
+                        <label wicket:id="purpose-label">
+                            <wicket:message key="field.label.purpose">Purpose</wicket:message>
+                        </label>
                         <span class="glyphicon glyphicon-question-sign" title="Purpose"
                               wicket:message="title:purpose.help"></span>
                     </div>
@@ -104,7 +116,9 @@
                 </div>
                 <div class="form-group" wicket:id="type-group">
                     <div class="col-sm-2 control-label">
-                        <label wicket:id="type-label">Type</label>
+                        <label wicket:id="type-label">
+                            <wicket:message key="field.label.type">Type</wicket:message>
+                        </label>
                         <span class="glyphicon glyphicon-question-sign" title="Type"
                               wicket:message="title:type.help"></span>
                     </div>
@@ -117,7 +131,9 @@
                 </div>
                 <div class="form-group" wicket:id="author-group">
                     <div class="col-sm-2 control-label">
-                        <label wicket:id="author-label">Author</label>
+                        <label wicket:id="author-label">
+                            <wicket:message key="field.label.author">Author</wicket:message>
+                        </label>
                         <span class="glyphicon glyphicon-question-sign" title="Author"
                               wicket:message="title:author.help"></span>
                     </div>
@@ -127,7 +143,9 @@
                 </div>
                 <div class="form-group" wicket:id="contact-group">
                     <div class="col-sm-2 control-label">
-                        <label wicket:id="contact-label">Contact</label>
+                        <label wicket:id="contact-label">
+                            <wicket:message key="field.label.contact">Contact</wicket:message>
+                        </label>
                         <span class="glyphicon glyphicon-question-sign" title="Contact"
                               wicket:message="title:contact.help"></span>
                     </div>
@@ -137,7 +155,9 @@
                 </div>
                 <div class="form-group" wicket:id="permission-group">
                     <div class="col-sm-2 control-label">
-                        <label wicket:id="permission-label">Re-use</label>
+                        <label wicket:id="permission-label">
+                            <wicket:message key="field.label.permission">Re-use</wicket:message>
+                        </label>
                         <span class="glyphicon glyphicon-question-sign" title="Re-use"
                               wicket:message="title:permission.help"></span>
                     </div>
@@ -147,7 +167,9 @@
                 </div>
                 <div class="form-group" wicket:id="thumbnail-group">
                     <div class="col-sm-2 control-label">
-                    <label wicket:id="thumbnail-label">Thumbnail</label>
+                    <label wicket:id="thumbnail-label">
+                        <wicket:message key="field.label.thumbnail">Thumbnail</wicket:message>
+                    </label>
                     <span class="glyphicon glyphicon-question-sign" title="Thumbnail" wicket:message="title:thumbnail.help"></span>
                     </div>
                     <div class="col-sm-10">
@@ -157,7 +179,9 @@
                 </div>
                 <div class="form-group" wicket:id="hidden-group">
                     <div class="col-sm-2 control-label">
-                        <label wicket:id="hidden-label">Hidden</label>
+                        <label wicket:id="hidden-label">
+                            <wicket:message key="field.label.hidden">Hidden</wicket:message>
+                        </label>
                         <span class="glyphicon glyphicon-question-sign" title="Hidden" wicket:message="title:hidden.help"></span>
                     </div>
                     <div class="col-sm-10">

--- a/shoal/tool/src/java/uk/ac/ox/it/shoal/pages/EditPage.java
+++ b/shoal/tool/src/java/uk/ac/ox/it/shoal/pages/EditPage.java
@@ -105,7 +105,7 @@ public class EditPage extends SakaiPage {
         List<String> types = getApplication().getMetaData(EditApplication.TYPE);
         ListMultipleChoice<String> type = new NoDefaultListMultipleChoice<>("type", types);
         purpose.add(new PropertyValidator<>());
-        FormComponentLabel typeLabel = new FormComponentLabel("type-label", purpose);
+        FormComponentLabel typeLabel = new FormComponentLabel("type-label", type);
         typeGroup.add(typeLabel);
         typeGroup.add(type);
         typeGroup.add(new ErrorBehaviour(type));

--- a/shoal/tool/src/java/uk/ac/ox/it/shoal/pages/SimpleSearchPage$ResultsPanel.html
+++ b/shoal/tool/src/java/uk/ac/ox/it/shoal/pages/SimpleSearchPage$ResultsPanel.html
@@ -17,14 +17,11 @@
 				</li>
 			</ul>
 		</div>
-		<div class="facet" wicket:id="author"></div>
-
-		<div class="facet" wicket:id="subject"></div>
-		<div class="facet" wicket:id="type"></div>
-
 		<div class="facet" wicket:id="purpose"></div>
-		<div class="facet" wicket:id="interactivity"></div>
+		<div class="facet" wicket:id="type"></div>
+		<div class="facet" wicket:id="subject"></div>
 		<div class="facet" wicket:id="level"></div>
+		<div class="facet" wicket:id="interactivity"></div>
 
 	</div>
 

--- a/shoal/tool/src/java/uk/ac/ox/it/shoal/pages/SimpleSearchPage.java
+++ b/shoal/tool/src/java/uk/ac/ox/it/shoal/pages/SimpleSearchPage.java
@@ -161,12 +161,12 @@ public class SimpleSearchPage extends SearchPage {
             filtersBox.add(filtersList);
             filtersBox.setVisible(filtersList.getViewSize() > 0);
 
+            add(provider.getFacet("purpose", "purpose", new FacetSort(FacetSort.On.COUNT, FacetSort.Order.DESC), null, p));
             add(provider.getFacet("type", "type", new FacetSort(FacetSort.On.COUNT, FacetSort.Order.DESC), null, p));
-            add(provider.getFacet("author", "author", new FacetSort(FacetSort.On.COUNT, FacetSort.Order.DESC), null, p));
             add(provider.getFacet("subject", "subject", new FacetSort(FacetSort.On.COUNT, FacetSort.Order.DESC), null, p));
             add(provider.getFacet("level", "level", new FacetSort(FacetSort.On.COUNT, FacetSort.Order.DESC), null, p));
-            add(provider.getFacet("purpose", "purpose", new FacetSort(FacetSort.On.COUNT, FacetSort.Order.DESC), null, p));
             add(provider.getFacet("interactivity", "interactivity", new FacetSort(FacetSort.On.COUNT, FacetSort.Order.DESC), null, p));
+
             add(provider.getOrderBy("order", p));
 
         }

--- a/shoal/tool/src/java/uk/ac/ox/it/shoal/wicket-package.properties
+++ b/shoal/tool/src/java/uk/ac/ox/it/shoal/wicket-package.properties
@@ -1,0 +1,15 @@
+field.label.author = Author
+field.label.contact = Contact
+field.label.description = Description
+field.label.title = Title
+field.label.subject = Subject
+field.label.level = Level
+field.label.purpose = Educational use
+field.label.interactivity = Interactivity
+field.label.permission = Re-use
+field.label.type = Resource type
+field.label.thumbnail = Thumbnail
+field.label.hidden = Hidden
+field.label.added = Added
+field.label.license = License
+field.label.updated = Last Updated


### PR DESCRIPTION
We had terms duplicated across applications, now we’re using proper i18n lookups in the edit application and have a common i18n file so that the fields are always identical in both parts.
Also dropped out some unused properties.