### PR TITLE
WL-4821: Incorrect 'Find It on Solo' links for Journal Articles

### DIFF
--- a/citations/citations-impl/impl/src/java/org/sakaiproject/citation/impl/soloapi/AbstractConverter.java
+++ b/citations/citations-impl/impl/src/java/org/sakaiproject/citation/impl/soloapi/AbstractConverter.java
@@ -72,6 +72,10 @@ public abstract class AbstractConverter implements Converter {
 					}
 				}
 			}
+			// links to journal articles thses extra parameters
+			if (this instanceof JournalConverter){
+				value = value.replace("&fn=display", "&fn=search&tab=remote");
+			}
 		}
 		return value;
 	}

--- a/citations/citations-impl/impl/src/test/org/sakaiproject/citation/impl/soloapi/SoloApiServiceImplTest.java
+++ b/citations/citations-impl/impl/src/test/org/sakaiproject/citation/impl/soloapi/SoloApiServiceImplTest.java
@@ -331,7 +331,7 @@ public class SoloApiServiceImplTest extends AbstractSingleSpringContextTests {
 		assertEquals("1847", citation.getCitationProperty("year", false));
 		assertEquals("Washington, D.C", citation.getCitationProperty("publicationLocation", false));
 		assertEquals("L.P. Noble", citation.getCitationProperty("publisher", false));
-		assertEquals("http://solo.bodleian.ox.ac.uk/primo_library/libweb/action/display.do?doc=oxfaleph011255518&vid=OXVU1&fn=display&displayMode=full", citation.getCitationProperty("otherIds", false));
+		assertEquals("http://solo.bodleian.ox.ac.uk/primo_library/libweb/action/display.do?doc=oxfaleph011255518&vid=OXVU1&fn=search&tab=remote&displayMode=full", citation.getCitationProperty("otherIds", false));
 	}
 
 	public void testParseSampleOther() {


### PR DESCRIPTION
Craig noticed that the Solo Urls for Journal Articles weren't going to the right place and wanted a couple of parameter changes to get them there, i.e., from this:

http://solo.bodleian.ox.ac.uk/primo_library/libweb/action/display.do?doc=TN_jstor_archive_172298044&vid=OXVU1&fn=display&displayMode=full

to this:

http://solo.bodleian.ox.ac.uk/primo_library/libweb/action/display.do?doc=TN_sagej10.1177_0191453713494972&vid=OXVU1&fn=search&displayMode=full&tab=remote