### PR TITLE
WL-4786 Fix replace site to work again.

### DIFF
--- a/tetraelf-hierarchy/hierarchy-tool/tool/src/java/org/sakaiproject/hierarchy/tool/vm/ReplaceSiteController.java
+++ b/tetraelf-hierarchy/hierarchy-tool/tool/src/java/org/sakaiproject/hierarchy/tool/vm/ReplaceSiteController.java
@@ -114,7 +114,7 @@ public class ReplaceSiteController{
 		return displaySites(request);
 	}
 
-	@RequestMapping(value = "/site/save", method = RequestMethod.POST)
+	@RequestMapping(value = "/save", method = RequestMethod.POST)
 	public String saveSite(HttpServletRequest request,ModelMap model, @RequestParam(REQUEST_SITE) String siteId) {
 		PortalNodeSite node = portalHierarchyService.getCurrentPortalNode();
 		if (siteId != null && !siteId.isEmpty()) {
@@ -125,6 +125,8 @@ public class ReplaceSiteController{
 						"You shouldn't have been able to select a site as you don't have permission.", e);
 			}
 		}
+		// Reload the current node now the site has been changed.
+		node = portalHierarchyService.getCurrentPortalNode();
 		model.put("siteUrl", node.getSite().getUrl());
 		return "redirect";
 	}

--- a/tetraelf-hierarchy/hierarchy-tool/tool/src/webapp/WEB-INF/velocity/replace.vm
+++ b/tetraelf-hierarchy/hierarchy-tool/tool/src/webapp/WEB-INF/velocity/replace.vm
@@ -6,7 +6,7 @@ $old.siteTitle
 <p>with the new site</p>
 $new.siteTitle
 <br/>
-<form method="post" action="${rootUrl}/site/save">
+<form method="post" action="${rootUrl}/save">
 <input type="hidden" name="_site" value="$!{new.siteId}" />
 <input type="submit" value="#springMessage("button.replace")"/>
 </form><br/>


### PR DESCRIPTION
This was broken because there are special tool paths that now get broken and this includes anything starting /site (ahhh). So we change the internal tool URL we are using. Also we were redirecting to the wrong URL, now we redirect back to the current location in the hierarchy, showing the new site in place.