### PR TITLE
WL-4898: Some Electronic Version links are circular

### DIFF
--- a/citations/citations-tool/tool/src/java/org/sakaiproject/citation/tool/CitationHelperAction.java
+++ b/citations/citations-tool/tool/src/java/org/sakaiproject/citation/tool/CitationHelperAction.java
@@ -3859,7 +3859,7 @@ public class CitationHelperAction extends VelocityPortletPaneledAction
 	            }
         	}
 
-        	if(label == null || url == null)
+        	if(label == null || url == null || url.equals(""))
         	{
         		if(logger.isDebugEnabled()) {
         			logger.debug("doCreateCitation: label null? " + label + " url null? " + url);


### PR DESCRIPTION
Currently, what is happening is that if you manually create a citation (and don't put anything in the URL field), the backend code creates a circular Electronic Version link if the URL is not null, and because  what actually gets submitted is an empty string, it creates this link.   This adds the empty string check so no URL is created for an empty field.  