### PR TITLE
WL-4916 Update MathJax to point to new location.

### DIFF
--- a/docker/sakai/placeholder.properties
+++ b/docker/sakai/placeholder.properties
@@ -866,3 +866,8 @@ assignment.anon.grading.enabled=true
 
 # Set the shoal site type
 shoal.site.type=repository
+
+# This is a temporary workaround until this property is in kernel.properties
+# WL-4916/KNL-1519
+portal.mathjax.src.path=https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=default,Safe
+


### PR DESCRIPTION
The old location should return a redirect at the end of the month, but it’s safer to just point to the new location ourselves.
When this gets merged in from upstream we can drop this config.