### PR TITLE
WL-4815: Adding in reference to the previous citationcollectionorder

### DIFF
--- a/citations/citations-impl/impl/src/java/org/sakaiproject/citation/impl/DbCitationService.java
+++ b/citations/citations-impl/impl/src/java/org/sakaiproject/citation/impl/DbCitationService.java
@@ -963,11 +963,13 @@ public class DbCitationService extends BaseCitationService
 		protected void deleteCitationCollectionOrder(CitationCollectionOrder citationCollectionOrder)
 		{
 			String statement = "delete from " + m_collectionOrderTableName + " where (" + m_collectionTableId + " = ? AND " +
-					"LOCATION = ? )";
+					"LOCATION = ? AND SECTION_TYPE = ? AND VALUE = ? )";
 
-			Object fields[] = new Object[2];
+			Object fields[] = new Object[4];
 			fields[0] = citationCollectionOrder.getCollectionId();
 			fields[1] = citationCollectionOrder.getLocation();
+			fields[2] = citationCollectionOrder.getSectiontype();
+			fields[3] = citationCollectionOrder.getValue();
 
 			boolean ok = m_sqlService.dbWrite(statement, fields);
 		}

--- a/citations/citations-impl/impl/src/java/org/sakaiproject/citation/impl/NestedCitationValidator.java
+++ b/citations/citations-impl/impl/src/java/org/sakaiproject/citation/impl/NestedCitationValidator.java
@@ -167,30 +167,35 @@ public class NestedCitationValidator implements CitationValidator {
 
 		// check the previous CitationCollectionOrder is of the correct type
 		List<CitationCollectionOrder> citationCollectionOrderList = getCitationService().getNestedCollectionAsList(collection.getId());
+		CitationCollectionOrder previousCitationCollectionOrder = null;
 		for (CitationCollectionOrder collectionOrder: citationCollectionOrderList) {
-			if (isH2){
-				//  check previous CitationCollectionOrder is an h1 h2 or description
-				if (!collectionOrder.getSectiontype().equals(CitationCollectionOrder.SectionType.HEADING1) &&
-						!collectionOrder.getSectiontype().equals(CitationCollectionOrder.SectionType.HEADING2) &&
-						!collectionOrder.getSectiontype().equals(CitationCollectionOrder.SectionType.DESCRIPTION)){
-					return "Invalid place to add subsection: trying to add an H2 to something other than an H1 H2 or a DESCRIPTION for collection id:" + citationCollectionOrder.getCollectionId();
-				}
+			if (collectionOrder.getLocation()==citationCollectionOrder.getLocation()-1){
+				previousCitationCollectionOrder = collectionOrder;
 			}
-			else if (isH3){
-				//  check previous CitationCollectionOrder is an h2 h3 or description
-				if (!collectionOrder.getSectiontype().equals(CitationCollectionOrder.SectionType.HEADING2) &&
-						!collectionOrder.getSectiontype().equals(CitationCollectionOrder.SectionType.HEADING3) &&
-						!collectionOrder.getSectiontype().equals(CitationCollectionOrder.SectionType.DESCRIPTION)){
-					return "Invalid place to add subsection: trying to add an H3 to something other than an H2 H3 or DESCRIPTION for collection id:" + citationCollectionOrder.getCollectionId();
-				}
+		}
+
+		if (isH2){
+			//  check previous CitationCollectionOrder is an h1 h2 or description
+			if (!previousCitationCollectionOrder.getSectiontype().equals(CitationCollectionOrder.SectionType.HEADING1) &&
+					!previousCitationCollectionOrder.getSectiontype().equals(CitationCollectionOrder.SectionType.HEADING2) &&
+					!previousCitationCollectionOrder.getSectiontype().equals(CitationCollectionOrder.SectionType.DESCRIPTION)){
+				return "Invalid place to add subsection: trying to add an H2 to something other than an H1 H2 or a DESCRIPTION for collection id:" + citationCollectionOrder.getCollectionId();
 			}
-			else if (isDescription){
-				//  check previous CitationCollectionOrder is an h1 h2 or h3
-				if (!collectionOrder.getSectiontype().equals(CitationCollectionOrder.SectionType.HEADING1) &&
-						!collectionOrder.getSectiontype().equals(CitationCollectionOrder.SectionType.HEADING2) &&
-						!collectionOrder.getSectiontype().equals(CitationCollectionOrder.SectionType.HEADING3)){
-					return "Invalid place to add subsection: trying to add a description to something other than an H1 H2 or H3 for collection id:" + citationCollectionOrder.getCollectionId();
-				}
+		}
+		else if (isH3){
+			//  check previous CitationCollectionOrder is an h2 h3 or description
+			if (!previousCitationCollectionOrder.getSectiontype().equals(CitationCollectionOrder.SectionType.HEADING2) &&
+					!previousCitationCollectionOrder.getSectiontype().equals(CitationCollectionOrder.SectionType.HEADING3) &&
+					!previousCitationCollectionOrder.getSectiontype().equals(CitationCollectionOrder.SectionType.DESCRIPTION)){
+				return "Invalid place to add subsection: trying to add an H3 to something other than an H2 H3 or DESCRIPTION for collection id:" + citationCollectionOrder.getCollectionId();
+			}
+		}
+		else if (isDescription){
+			//  check previous CitationCollectionOrder is an h1 h2 or h3
+			if (!previousCitationCollectionOrder.getSectiontype().equals(CitationCollectionOrder.SectionType.HEADING1) &&
+					!previousCitationCollectionOrder.getSectiontype().equals(CitationCollectionOrder.SectionType.HEADING2) &&
+					!previousCitationCollectionOrder.getSectiontype().equals(CitationCollectionOrder.SectionType.HEADING3)){
+				return "Invalid place to add subsection: trying to add a description to something other than an H1 H2 or H3 for collection id:" + citationCollectionOrder.getCollectionId();
 			}
 		}
 		return null;

--- a/citations/citations-impl/impl/src/java/org/sakaiproject/citation/impl/NestedCitationValidator.java
+++ b/citations/citations-impl/impl/src/java/org/sakaiproject/citation/impl/NestedCitationValidator.java
@@ -173,6 +173,9 @@ public class NestedCitationValidator implements CitationValidator {
 				previousCitationCollectionOrder = collectionOrder;
 			}
 		}
+		if (previousCitationCollectionOrder == null) {
+			return "Failed to find previous item for collection id: "+ citationCollectionOrder.getCollectionId();
+		}
 
 		if (isH2){
 			//  check previous CitationCollectionOrder is an h1 h2 or description


### PR DESCRIPTION
The test plan for this WL-4815 Jira is failing because of a code change made for WL-4812.  I've committed this code change against the WL-4815 Jira because it's the one we'll need to re-test.

The WL-4812 Jira is to do with adding in validation when making changes to citation lists (https://github.com/ox-it/sakai/pull/370).  

The change here is that, when adding a subsection, we validate to make sure the previous section is of the right type, e.g., an h2 before an h3 ,etc.  I missed including a reference to the previous section :)

Also, I put the parameters in for the deleteCitationCollectionOrder method as removing them broke lots of things.
 