### PR TITLE
WL-4846: Polls vote via POST to /direct results in 405

### DIFF
--- a/polls/tool/src/java/org/sakaiproject/poll/tool/entityproviders/PollsEntityProvider.java
+++ b/polls/tool/src/java/org/sakaiproject/poll/tool/entityproviders/PollsEntityProvider.java
@@ -894,7 +894,7 @@ public class PollsEntityProvider extends AbstractEntityProvider implements
 	 * pollOption parameters.
 	 */
 	@EntityCustomAction(action = "vote", viewKey = EntityView.VIEW_NEW)
-	public List<Vote> vote(EntityView view, EntityReference ref, String prefix,
+	public void vote(EntityView view, EntityReference ref, String prefix,
 			Search search, OutputStream out, Map<String, Object> params) {
 		Long pollId = null;
 		try {
@@ -997,7 +997,6 @@ public class PollsEntityProvider extends AbstractEntityProvider implements
 			}
 			votes.add(vote);
 		}
-		return votes;
 	}
 
 	/**


### PR DESCRIPTION
I was working on another fix but this one seems cleaner and more elegant.   'Messages' and 'gradebook' work the same way and don't return anything.  There dosen't seem a need to return something in the same way that a GET request does.  This avoids the error page Damion was seeing and still updates the poll's votes. 