### PR TITLE
WL-4834 Include portal.include.extrahead on site display

### DIFF
--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/site/impl/BaseSiteService.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/site/impl/BaseSiteService.java
@@ -2367,6 +2367,7 @@ public abstract class BaseSiteService implements SiteService, Observer
 					if (serverConfigurationService().getBoolean("content.mixedContent.forceLinksInNewWindow", true)) {
 						out.println("<script type=\"text/javascript\" language=\"JavaScript\" src=\"/library/js/headscripts.js\"></script>");
 					}
+					out.println(serverConfigurationService().getString("portal.include.extrahead", ""));
 
 					out.println("<title>");
 					out.println(site.getTitle());


### PR DESCRIPTION
When displaying the site entity include the portal.include.extrahead property as well. This means that this property is now displayed on HTML pages from resources, in the portal and on Site entities.