### PR TITLE
WL-4909 Handle situation where title can be supplied

### DIFF
--- a/basiclti/basiclti-api/src/java/org/sakaiproject/lti/api/LTIService.java
+++ b/basiclti/basiclti-api/src/java/org/sakaiproject/lti/api/LTIService.java
@@ -527,4 +527,14 @@ public interface LTIService {
 	 * @return <code>true</code> if the user has to provide some more configuration.
 	 */
 	boolean needsConfig(Map<String, Object> tool, String[] contentToolModel);
+
+    /**
+     * This returns the default properties that an instance of the tool should have.
+     * This is useful when you want to create an instance of the tool, but don't want to prompt the user to confirm
+     * any of the configuration.
+     * @param ltiTool The LTI tool.
+     * @param contentToolModel The model for the tool.
+     * @return The default required values.
+     */
+    Properties defaultConfig(Map<String, Object> ltiTool, String[] contentToolModel);
 }

--- a/basiclti/basiclti-impl/src/java/org/sakaiproject/lti/impl/BaseLTIService.java
+++ b/basiclti/basiclti-impl/src/java/org/sakaiproject/lti/impl/BaseLTIService.java
@@ -296,6 +296,18 @@ public abstract class BaseLTIService implements LTIService {
 		return false;
 	}
 
+	public Properties defaultConfig(Map<String, Object> tool, String[] fieldInfos) {
+		Properties props = new Properties();
+		for (String fieldInfo: fieldInfos) {
+			Properties info = foorm.parseFormString(fieldInfo);
+			if ("true".equals(info.getProperty("required", null))) {
+				String field = info.getProperty("field");
+				props.put(field, tool.get(field));
+			}
+		}
+		return props;
+	}
+
 	@Override
 	public boolean hideConfig(Map<String, Object> tool, String[] contentToolModel) {
 		Object hideconfig = tool.get("hideconfig");

--- a/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
+++ b/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
@@ -11840,9 +11840,14 @@ private Map<String,List> getTools(SessionState state, String type, Site site) {
 				if (!oldLtiTools.containsKey(ltiToolId))
 				{
 					Map<String, Object> toolValues = ltiTool.getValue();
-					Properties reqProperties = (Properties) toolValues.get("reqProperties");
-					if (reqProperties==null) {
-						reqProperties = new Properties();
+					// Need to copy in default required.
+					String[] contentModel = m_ltiService.getContentModel(new Long(ltiToolId), site.getId());
+					Properties reqProperties = m_ltiService.defaultConfig(ltiTool.getValue(), contentModel);
+					// This holds any properties that have come back from the form if shown
+					Properties editedProperties = (Properties) toolValues.get("reqProperties");
+					if (editedProperties!=null) {
+						// Overwrite with anything that's come back from the form
+						reqProperties.putAll(editedProperties);
 					}
 					Object retval = m_ltiService.insertToolContent(null, ltiToolId, reqProperties, site.getId());
 					if (retval instanceof String)


### PR DESCRIPTION
If the tool configuration is hidden but the user can change the title then we need to supply the default title when we’re inserting the tool content.