### PR TITLE
WL-4812: Validate on saving any change to a nested reading list

### DIFF
--- a/citations/citations-impl/impl/src/java/org/sakaiproject/citation/impl/NestedCitationValidator.java
+++ b/citations/citations-impl/impl/src/java/org/sakaiproject/citation/impl/NestedCitationValidator.java
@@ -178,19 +178,22 @@ public class NestedCitationValidator implements CitationValidator {
 		}
 
 		if (isH2){
-			//  check previous CitationCollectionOrder is an h1 h2 or description
+			//  check previous CitationCollectionOrder is an h1 h2 h3 or description or citation
 			if (!previousCitationCollectionOrder.getSectiontype().equals(CitationCollectionOrder.SectionType.HEADING1) &&
 					!previousCitationCollectionOrder.getSectiontype().equals(CitationCollectionOrder.SectionType.HEADING2) &&
+					!previousCitationCollectionOrder.getSectiontype().equals(CitationCollectionOrder.SectionType.HEADING3) &&
+					!previousCitationCollectionOrder.getSectiontype().equals(CitationCollectionOrder.SectionType.CITATION) &&
 					!previousCitationCollectionOrder.getSectiontype().equals(CitationCollectionOrder.SectionType.DESCRIPTION)){
-				return "Invalid place to add subsection: trying to add an H2 to something other than an H1 H2 or a DESCRIPTION for collection id:" + citationCollectionOrder.getCollectionId();
+				return "Invalid place to add subsection: trying to add an H2 to something other than an H1 H2 H3 or a DESCRIPTION or CITATION for collection id:" + citationCollectionOrder.getCollectionId();
 			}
 		}
 		else if (isH3){
-			//  check previous CitationCollectionOrder is an h2 h3 or description
+			//  check previous CitationCollectionOrder is an h2 h3 or description or citation
 			if (!previousCitationCollectionOrder.getSectiontype().equals(CitationCollectionOrder.SectionType.HEADING2) &&
 					!previousCitationCollectionOrder.getSectiontype().equals(CitationCollectionOrder.SectionType.HEADING3) &&
+					!previousCitationCollectionOrder.getSectiontype().equals(CitationCollectionOrder.SectionType.CITATION) &&
 					!previousCitationCollectionOrder.getSectiontype().equals(CitationCollectionOrder.SectionType.DESCRIPTION)){
-				return "Invalid place to add subsection: trying to add an H3 to something other than an H2 H3 or DESCRIPTION for collection id:" + citationCollectionOrder.getCollectionId();
+				return "Invalid place to add subsection: trying to add an H3 to something other than an H2 H3 or DESCRIPTION or CITATION for collection id:" + citationCollectionOrder.getCollectionId();
 			}
 		}
 		else if (isDescription){
@@ -226,7 +229,7 @@ public class NestedCitationValidator implements CitationValidator {
 	@Override
 	public String getDragAndDropErrorMessage(List<CitationCollectionOrder> citationCollectionOrders, CitationCollection collection) {
 
-		for (CitationCollectionOrder h1Section : citationCollectionOrders.get(0).getChildren()) {
+		for (CitationCollectionOrder h1Section : citationCollectionOrders) {
 			if (!Arrays.asList(NESTED_CITATION_LIST.TOP_LEVEL.getAllowableTypes()).contains(
 					h1Section.getSectiontype())){
 				return "Invalid nested list: when checking H1 with value: " + h1Section.getValue() + " for collection with id: " +  h1Section.getCollectionId();

--- a/citations/citations-tool/tool/src/webapp/js/new_resource.js
+++ b/citations/citations-tool/tool/src/webapp/js/new_resource.js
@@ -51,6 +51,7 @@ var reportSuccess = function(msg){
  */
 var reportError = function(msg){
     $('#messageError').html(msg).show();
+    window.scrollTo(0, 0);
 };
 
 /*


### PR DESCRIPTION
This has in it: 
i. scrolling to the top of the screen to bring the error message into view when there is one 
ii. allowing some drag and drop moves that were being incorrectly caught when validating.