### PR TITLE
WL-4935 Increase file upload limit to 250MB.

### DIFF
--- a/docker/sakai/placeholder.properties
+++ b/docker/sakai/placeholder.properties
@@ -111,10 +111,8 @@ emailFromReplyable@org.sakaiproject.event.api.NotificationService=true
 email.precedence.bulk=true
 
 # RESOURCES/COLLECTIONS CONFIGURATION
-#WL-1360 increase upload ceiling to 400MB
-
 # upload limit per request, in megs
-content.upload.max=100
+content.upload.max=250
 # upload ceiling (upload limit increase can be requested via URL param, up to this ceiling) in megs
 content.upload.ceiling=400
 


### PR DESCRIPTION
Now we have removed the use of byte arrays it’s safer to increase the upload limit further.