### PR TITLE
WL-4913 Force submissions sites to include Site Info

### DIFF
--- a/docker/sakai/Dockerfile
+++ b/docker/sakai/Dockerfile
@@ -16,7 +16,7 @@ COPY tomcat/lib /opt/tomcat/sakai-lib/
 COPY tomcat/webapps /opt/tomcat/webapps/
 
 # We don't copy local.properties for production
-COPY krb5.conf log4j.properties placeholder.properties sakai.quartz.properties sakai-jaas.conf jgroups-config.xml /opt/tomcat/sakai/
+COPY krb5.conf log4j.properties placeholder.properties sakai.quartz.properties sakai-jaas.conf jgroups-config.xml toolOrder.xml /opt/tomcat/sakai/
 COPY override /opt/tomcat/sakai/override
 COPY libyjpagent.so /opt/yjp/bin/linux-x86-64/
 COPY startup_with_yjp.sh /opt/tomcat/bin/

--- a/docker/sakai/docker-compose.yml
+++ b/docker/sakai/docker-compose.yml
@@ -20,6 +20,7 @@ app:
    - ./krb5.conf:/opt/tomcat/sakai/krb5.conf
    - ./sakai-keytab:/opt/tomcat/sakai/sakai-keytab
    - ./jgroups-config.xml:/opt/tomcat/sakai/jgroups-config.xml
+   - ./toolOrder.xml:/opt/tomcat/sakai/toolOrder.xml
    # Yourkit stuff
    - ./libyjpagent.so:/opt/yjp/bin/linux-x86-64/libyjpagent.so
    - ./startup_with_yjp.sh:/opt/tomcat/bin/startup_with_yjp.sh

--- a/docker/sakai/toolOrder.xml
+++ b/docker/sakai/toolOrder.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0"?>
+
+<toolOrder>
+
+	<category name="myworkspace">
+		<tool id = "home" selected="true" />
+		<tool id = "sakai.dashboard" />
+		<tool id = "sakai.sitesetup" required = "true" />
+		<tool id = "sakai.membership" required="true" />
+		<tool id = "sakai.preferences" required="true" />
+
+	</category>
+
+	<category name="course">
+		<tool id = "sakai.iframe.site" />
+		<tool id = "sakai.dashboard" />
+		<tool id = "sakai.synoptic.chat" />
+		<tool id = "sakai.synoptic.messagecenter" />
+		<tool id = "sakai.synoptic.announcement" />
+		<tool id = "home" selected = "true" />
+		<tool id = "sakai.syllabus" />
+		<tool id = "sakai.lessonbuildertool" />
+		<tool id = "sakai.schedule" />
+		<tool id = "sakai.announcements" selected = "true" />
+		<tool id = "sakai.resources" />
+		<tool id = "sakai.forums" />
+		<tool id = "sakai.assignment" />
+		<tool id = "sakai.assignment.grades" />
+		<tool id = "sakai.samigo" />
+		<tool id = "sakai.gradebook.tool" />
+		<tool id = "sakai.dropbox" />
+		<tool id = "sakai.chat" />
+		<tool id = "sakai.rwiki" />
+		<tool id = "sakai.mailbox" />
+		<tool id = "sakai.news" />
+		<tool id = "sakai.iframe" />
+		<tool id = "sakai.presentation" />
+		<tool id = "sakai.sections" />
+		<tool id = "sakai.site.roster" />
+		<tool id = "sakai.siteinfo" required = "true" />
+		<tool id = "sakai.feedback" required = "true" />
+
+	</category>
+
+	<category name="project">
+		<tool id = "sakai.iframe.site" />
+		<tool id = "sakai.dashboard" />
+		<tool id = "sakai.synoptic.chat" />
+		<tool id = "sakai.synoptic.messagecenter" />
+		<tool id = "sakai.synoptic.announcement" />
+		<tool id = "home" selected = "true" />
+		<tool id = "sakai.syllabus" />
+		<tool id = "sakai.lessonbuildertool" />
+		<tool id = "sakai.schedule" />
+		<tool id = "sakai.announcements" />
+		<tool id = "sakai.resources" />
+		<tool id = "sakai.forums" />
+		<tool id = "sakai.assignment" />
+		<tool id = "sakai.assignment.grades" />
+		<tool id = "sakai.samigo" />
+		<tool id = "sakai.gradebook.tool" />
+		<tool id = "sakai.dropbox" />
+		<tool id = "sakai.chat" />
+		<tool id = "sakai.rwiki" />
+		<tool id = "sakai.mailbox" />
+		<tool id = "sakai.news" />
+		<tool id = "sakai.iframe" />
+		<tool id = "sakai.presentation" />
+		<tool id = "sakai.sections" />
+		<tool id = "sakai.site.roster" />
+		<tool id = "sakai.siteinfo" required = "true" />
+		<tool id = "sakai.feedback" required = "true" />
+	</category>
+
+        <category name="submission">
+                <tool id = "sakai.iframe.site" />
+                <tool id = "sakai.synoptic.announcement" />
+                <tool id = "home" selected = "true" />
+                <tool id = "sakai.schedule" />
+                <tool id = "sakai.announcements" />
+                <tool id = "sakai.resources" />
+                <tool id = "sakai.assignment" />
+                <tool id = "sakai.siteinfo" required = "true" />
+                <tool id = "sakai.feedback" required = "true" />
+        </category>
+</toolOrder>

--- a/feedback/src/webapp/tools/sakai.feedback.xml
+++ b/feedback/src/webapp/tools/sakai.feedback.xml
@@ -6,6 +6,7 @@
     
     	<category name="course" />
         <category name="project" />
+		<category name="submission" />
 
 		<configuration name="reset.button" value="false"/>
 


### PR DESCRIPTION
The Site Info tool should be force into all the submission sites. This moves our toolOrder.xml outside Sakai codebase so we’re patching less. Also makes feedback available in the submissions sites. Although because of our creation process the feedback tool was already always available, however it never showed up in the edit tools list because it wasn’t considered a valid tool.