### PR TITLE
WL-4950 Upgrade the raven connector.

### DIFF
--- a/deploy/common/pom.xml
+++ b/deploy/common/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>org.sakaiproject.sentry</groupId>
             <artifactId>raven-sakai</artifactId>
-            <version>1.1</version>
+            <version>1.2</version>
         </dependency>
     </dependencies>
 </project>

--- a/docker/sakai/log4j.properties
+++ b/docker/sakai/log4j.properties
@@ -2,7 +2,7 @@ log4j.rootLogger=WARN, console, sentry, catalina
 
 # Sentry setup
 # The DSN should be supplied through the envrionment
-log4j.appender.sentry=net.kencochrane.raven.log4j.SentryAppender
+log4j.appender.sentry=com.getsentry.raven.log4j.SentryAppender
 # This is so that we get the correct hostname in docker
 log4j.appender.sentry.ravenFactory=org.sakaiproject.sentry.DockerRavenFactory
 log4j.appender.sentry.Threshold=ERROR


### PR DESCRIPTION
This has the different package namespace so the logging needs updating as well. This uses raven 8.0.x under the hood.