### PR TITLE
WL-4801 Copying forums between sites didn’t work.

### DIFF
--- a/msgcntr/messageforums-components/src/webapp/WEB-INF/components.xml
+++ b/msgcntr/messageforums-components/src/webapp/WEB-INF/components.xml
@@ -55,6 +55,9 @@
         <property name="authzGroupService">
             <ref bean="org.sakaiproject.authz.api.AuthzGroupService"/>
         </property>
+        <property name="contentCopy">
+            <ref bean="org.sakaiproject.content.api.ContentCopy"/>
+        </property>
     </bean>
 	    
     <bean id="org.sakaiproject.api.app.messageforums.MessageForumsTypeManager" 


### PR DESCRIPTION
The problem was that the content copy service wasn’t getting injected and as this was only used when duplicating forums it doesn’t cause any other problems.