### PR TITLE
WL-4959: Change dull, ugly brown-grey top banner to consistent Oxford blue

### DIFF
--- a/reference/library/src/morpheus-master/sass/oxford/_overrides.scss
+++ b/reference/library/src/morpheus-master/sass/oxford/_overrides.scss
@@ -98,6 +98,11 @@
     }
 }
 
+/*  Make colour of top part of banner Oxford blue */
+.#{$namespace}mainHeader .#{$namespace}topHeader, .#{$namespace}mainHeader.is-maximized .#{$namespace}topHeader .siteNavWrap {
+    background: linear-gradient(to right, $header-gradient-a, $header-gradient-b, $header-gradient-c, $header-gradient-d);
+}
+
 /* Extra icon mappings specific to WL. */
 @if $skin-with-icons {
     /* This selector is required as some local tools don't start with 'icon-sakai-'. */


### PR DESCRIPTION
I'm changing the background here to the same as what it is for the breadcrumb, Oxford-blue part of the banner.

The change is in two places -  the first is for when you are logged out, the second is when you are logged in for the favourite sites background.