### PR TITLE
WL-4964 Fix for course signup rendering badly.

### DIFF
--- a/course-signup/tool/src/main/webapp/static/advance.jsp
+++ b/course-signup/tool/src/main/webapp/static/advance.jsp
@@ -26,8 +26,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<!-- Make the page render as IE8 for wrapping in jstree -->
-<meta http-equiv="X-UA-Compatible" content="IE=8">
 
 <title>Course Signup</title>
 

--- a/course-signup/tool/src/main/webapp/static/course.jsp
+++ b/course-signup/tool/src/main/webapp/static/course.jsp
@@ -30,8 +30,6 @@ pageContext.setAttribute("openCourse", (String)request.getAttribute("openCourse"
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-	<!-- Make the page render as IE8 for wrapping in jstree -->
-	<meta http-equiv="X-UA-Compatible" content="IE=8" >
 
 	<title>Show Course Details</title>
 

--- a/course-signup/tool/src/main/webapp/static/home.jsp
+++ b/course-signup/tool/src/main/webapp/static/home.jsp
@@ -24,10 +24,6 @@
 <head>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 	
-	<!--  IE8 runnung in IE7 compatability mode breaks this page 
-	       work around is the line below --> 
-	<meta http-equiv="X-UA-Compatible" content="IE=8">
-	
 	<title>Course Search</title>
 
 	<link href='<c:out value="${skinRepo}" />/tool_base.css' type="text/css" rel="stylesheet" media="all" />

--- a/course-signup/tool/src/main/webapp/static/index.jsp
+++ b/course-signup/tool/src/main/webapp/static/index.jsp
@@ -28,8 +28,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<!-- Make the page render as IE8 for wrapping in jstree -->
-<meta http-equiv="X-UA-Compatible" content="IE=8">
 
 <title>Browse by Department</title>
 

--- a/course-signup/tool/src/main/webapp/static/ok.jsp
+++ b/course-signup/tool/src/main/webapp/static/ok.jsp
@@ -26,8 +26,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<!-- Make the page render as IE8 for wrapping in jstree -->
-<meta http-equiv="X-UA-Compatible" content="IE=8">
 
 <title>Module Signup</title>
 

--- a/course-signup/tool/src/main/webapp/static/quartz.jsp
+++ b/course-signup/tool/src/main/webapp/static/quartz.jsp
@@ -29,9 +29,6 @@ pageContext.setAttribute("jobTypes", ServerConfigurationService.getStrings("ses.
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-	<!-- Make the page render as IE8 for wrapping in jstree 
-	<meta http-equiv="X-UA-Compatible" content="IE=8" >
-	-->
 	<title>Module Signup</title>
  
 	<link href='<c:out value="${skinRepo}" />/tool_base.css' type="text/css" rel="stylesheet" media="all" />

--- a/course-signup/tool/src/main/webapp/static/vitae.jsp
+++ b/course-signup/tool/src/main/webapp/static/vitae.jsp
@@ -27,10 +27,6 @@
 <head>
  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 
- <!-- IE8 runnung in IE7 compatability mode breaks this page 
-     work around is the line below --> 
- <meta http-equiv="X-UA-Compatible" content="IE=8">
-
  <title>Researcher Development</title>
 
  <link href='<c:out value="${skinRepo}" />/tool_base.css' type="text/css" rel="stylesheet" media="all" />


### PR DESCRIPTION
With course signup moving out of an iframe on Sakai 11 it causes the whole of Sakai to render badly in IE11. The reason is that it forces Sakai to render everything in IE 8 mode which doesn’t work at all. Switching to render in IE11 mode looks to generally be better although there maybe some quirks in edge cases.

However this change shouldn’t affect anything other than IE so it should be reasonably low risk for everyone else.