### PR TITLE
WL-4960: Backing out this change to think some more on it

### DIFF
--- a/reference/library/src/morpheus-master/sass/oxford/_overrides.scss
+++ b/reference/library/src/morpheus-master/sass/oxford/_overrides.scss
@@ -135,26 +135,3 @@
     .icon-sakai-oxam-admin{                  @extend .fa-gears;}
     .icon-oxford-podcasts {                  @extend .fa-volume-up;}
 }
-
-/* Show the breadcrumbs on one rows (when there are parent sites) */
-.#{$namespace}siteHierarchy {
-
-  @media #{$nonPhone}{
-
-	.Mrphs-siteHierarchyAlign {
-	  display: flex;
-	  justify-content: center;
-	  float: left;
-
-	  .Mrphs-hierarchy--parent-sites, .Mrphs-hierarchy--siteName, .Mrphs-hierarchy--siteNameSeparator, .Mrphs-hierarchy--toolName  {
-		align-self: center;
-		padding-top: 2rem;
-		padding-bottom: 0px;
-		font-size: 100%;
-		margin-right: 10px;
-		margin-bottom: 0;
-		font-weight: normal;
-	  }
-	}
-  }
-}


### PR DESCRIPTION
Adam says: "My main problem is that once you're in the hierarchy, the tool title that people have been clicking on for several years could be way over on the right of the screen. The tool title should always be in the same place on the screen, it should never be in an unexpected location."