### PR TITLE
WL-4976 Remove custom hibernate index creation.

### DIFF
--- a/content-sync/impl/src/main/java/uk/ac/ox/oucs/vle/contentsync/ContentSyncDAOImpl.java
+++ b/content-sync/impl/src/main/java/uk/ac/ox/oucs/vle/contentsync/ContentSyncDAOImpl.java
@@ -16,34 +16,7 @@ import org.springframework.orm.hibernate3.support.HibernateDaoSupport;
 
 public class ContentSyncDAOImpl extends HibernateDaoSupport implements ContentSyncDAO {
 
-	private static final Log log = LogFactory.getLog(ContentSyncDAOImpl.class);
-	
-	private static final String INDEX_SQL = "CREATE INDEX content_sync_idx ON content_sync (context, timeStamp)";
-	
-	private ServerConfigurationService serverConfigurationService;
-	public void setServerConfigurationService(
-			ServerConfigurationService serverConfigurationService) {
-		this.serverConfigurationService = serverConfigurationService;
-	}
-
 	public void init() {
-		if (serverConfigurationService.getBoolean("auto.ddl", true)) {
-			
-			Session session = getSession();
-			Transaction ta = session.beginTransaction();
-			try {
-				// Hibernate fails to create this index so we do it manually.
-				SQLQuery createSQLQuery = session.createSQLQuery(INDEX_SQL);
-				createSQLQuery.executeUpdate();
-				ta.commit();
-				log.info("Created indexes.");
-			} catch (HibernateException e ) {
-				// This will fail on all subsequent restarts 
-				log.debug("Failed to create index: '"+ INDEX_SQL+ "' "+ e.getMessage() );
-				ta.rollback();
-				session.close();
-			}
-		}
 	}
 	
 	public void save(ContentSyncTableDAO resourceTrackerDao) {

--- a/content-sync/impl/src/main/resources/content-sync.xml
+++ b/content-sync/impl/src/main/resources/content-sync.xml
@@ -32,9 +32,6 @@
 					<ref
 						bean="org.sakaiproject.springframework.orm.hibernate.GlobalSessionFactory" />
 				</property>
-				<property name="serverConfigurationService">
-					<ref bean="org.sakaiproject.component.api.ServerConfigurationService" />
-				</property>
 			</bean>
 		</property>
 		<property name="transactionAttributes">

--- a/tetraelf-hierarchy/hierarchy-api/api/src/java/org/sakaiproject/hierarchy/impl/portal/dao/PortalPersistentNode.hbm.xml
+++ b/tetraelf-hierarchy/hierarchy-api/api/src/java/org/sakaiproject/hierarchy/impl/portal/dao/PortalPersistentNode.hbm.xml
@@ -14,18 +14,12 @@
       <id name="id" type="string">
          <column name="ID" />
       </id>
-      <property name="siteId" type="string" length="64">
-        <!-- The index creation doesn't work but is here for reference -->
-        <column name="siteId" index="portal_node_site_id_idx"/>
-      </property>
+      <property name="siteId" type="string" length="64" index="portal_node_site_id_idx"/>
       <property name="managementSiteId" type="string" length="64" />
       <property name="name" type="string" length="64" />
       <property name="path" type="string" not-null="true" />
-      <property name="pathHash" type="string">
-        <!-- This should be unique but then hibernate creates an index with the wrong name. -->
-        <!-- The index creation doesn't work but is here for reference -->
-        <column name="pathHash" index="portal_node_path_hash_idx"  not-null="true" />
-      </property>
+      <!-- The unique-key value isn't used in the index name, but the index is correctly created -->
+      <property name="pathHash" type="string" unique-key="portal_node_path_hash_idx" not-null="true"/>
       <property name="redirectUrl" type="text" />
       <property name="redirectTitle" type="string" length="99"/>
       <property name="appendPath" type="boolean" not-null="true"/>

--- a/tetraelf-hierarchy/hierarchy-impl/impl/src/java/org/sakaiproject/hierarchy/impl/portal/dao/PortalPersistentNodeDaoHibernate.java
+++ b/tetraelf-hierarchy/hierarchy-impl/impl/src/java/org/sakaiproject/hierarchy/impl/portal/dao/PortalPersistentNodeDaoHibernate.java
@@ -11,42 +11,8 @@ import java.util.Date;
 import java.util.List;
 
 public class PortalPersistentNodeDaoHibernate extends HibernateDaoSupport implements PortalPersistentNodeDao {
-	
-	private static final Log log = LogFactory.getLog(PortalPersistentNodeDaoHibernate.class);
-
-	private static final String INDEX_SITE_ID = "create index portal_node_site_id_idx on PORTAL_NODE (siteId)";
-	private static final String INDEX_PATH_HASH = "create unique index portal_node_path_hash_idx on PORTAL_NODE (pathHash)";
-
-	private boolean ddl = true;
-
-	public void setDdl(boolean ddl) {
-		this.ddl = ddl;
-	}
 
 	public void init() {
-		if (ddl) {
-			Session session = getSession();
-			Transaction ta = session.beginTransaction();
-			SQLQuery createSQLQuery;
-			try {
-				// Hibernate (3.2.7) fails to create these indexes so we do it manually.
-				// With later versions of hibernate this can go away.
-				createSQLQuery = session.createSQLQuery(INDEX_SITE_ID);
-				createSQLQuery.executeUpdate();
-				createSQLQuery = session.createSQLQuery(INDEX_PATH_HASH);
-				createSQLQuery.executeUpdate();
-				ta.commit();
-				log.info("Created indexes.");
-			} catch (HibernateException e ) {
-				// This will fail on all subsequent restarts
-				// On MySQL at least this comes through as a SQL Grammar exception so it isn't easy to
-				// see when it's failing due to index already existing.
-				log.debug("Failed to create index: "+ e.getMessage() );
-				ta.rollback();
-			} finally {
-				session.close();
-			}
-		}
 	}
 
 	@Override

--- a/tetraelf-hierarchy/hierarchy-impl/pack/src/webapp/WEB-INF/portal-spring-hibernate.xml
+++ b/tetraelf-hierarchy/hierarchy-impl/pack/src/webapp/WEB-INF/portal-spring-hibernate.xml
@@ -7,12 +7,6 @@
          class="org.sakaiproject.hierarchy.impl.portal.dao.PortalPersistentNodeDaoHibernate"
          init-method="init">
       <property name="sessionFactory" ref="org.sakaiproject.springframework.orm.hibernate.GlobalSessionFactory" />
-      <property name="ddl">
-          <bean factory-bean="org.sakaiproject.component.api.ServerConfigurationService" factory-method="getBoolean">
-            <constructor-arg value="auto.ddl"/>
-            <constructor-arg value="true"/>
-          </bean>
-      </property>
    </bean>
 
    <bean id="org.sakaiproject.hierarchy.impl.portal.dao.PortalPersistenNodeDao" 


### PR DESCRIPTION
We rely instead on hibernate creating indexes itself when DDL is set. The name of the pathHash index changes, but this doesn’t appear to be an issue. This gets rid of some errors in the logs that weren’t actually errors but were expected when starting up against an existing database.