### PR TITLE
WL-5009: Can add extrnal users with ox.ac.uk and *.ox.ac.uk domains

### DIFF
--- a/docker/sakai/placeholder.properties
+++ b/docker/sakai/placeholder.properties
@@ -168,6 +168,7 @@ databaseXmlCache@org.sakaiproject.citation.api.ConfigurationService=categories.x
 # Only works in 2.4 will need to change to 2.5 to
 # invalidNonOfficialAccountString
 invalidNonOfficialAccountString=ox.ac.uk
+invalidEmailInIdAccountString=ox.ac.uk,oxford.ac.uk
 
 # WL-1035 Tell people more about new site
 # WL-1286 improve welcome to site email message


### PR DESCRIPTION
Adam asked for this line to be added to placeholder.properties.