### PR TITLE
WL-4984: Drag and dropping from h1 to h3 causes error

### DIFF
--- a/citations/citations-impl/impl/src/java/org/sakaiproject/citation/impl/NestedCitationValidator.java
+++ b/citations/citations-impl/impl/src/java/org/sakaiproject/citation/impl/NestedCitationValidator.java
@@ -94,9 +94,9 @@ public class NestedCitationValidator implements CitationValidator {
 					|| citationCollectionOrder.getSectiontype().equals(CitationCollectionOrder.SectionType.DESCRIPTION)) && citationCollectionOrder.getCitationid()!=null){
 				return "Invalid nested list: SECTION_TYPE is a 'HEADING' or a 'DESCRIPTION' and CITATION_ID is null for collection with id: " + collection.getId();
 			}
-			// 3. Check that if VALUE column is not null then section type column is not null and CITATION_ID is null
-			if (citationCollectionOrder.getValue()!=null && (citationCollectionOrder.getSectiontype()==null || citationCollectionOrder.getCitationid()!=null)){
-				return "Invalid nested list: VALUE is not null but either SECTION_TYPE is null or CITATION_ID is not null for collection with id: " + collection.getId();
+			// 3. Check that if VALUE column is not null then section type column is not null
+			if (citationCollectionOrder.getValue()!=null && citationCollectionOrder.getSectiontype()==null){
+				return "Invalid nested list: VALUE is not null but either SECTION_TYPE is null for collection with id: " + collection.getId();
 			}
 
 		}


### PR DESCRIPTION
This is the removal of one piece of validation that has been causing a lot of trouble, namely that the VALUE column be null when the CITATION_COLLECTION_ORDER is a CITATION.  If it is not null, it doesn't actually affect anything.  But if it is null, the list is uneditable. 

The proper fix (which is coming) is to make sure this column never gets populated in that situation but this has proved to be difficult, v hard to reproduce and not quick and so to get Craig's team going  with their lists, this fix is going in.     

This also fixes WL-4987.