### PR TITLE
WL-4904: On a public site, the resources folder listing isnt shown...

### DIFF
--- a/content/content-tool/tool/src/java/org/sakaiproject/content/entityproviders/ContentEntityProvider.java
+++ b/content/content-tool/tool/src/java/org/sakaiproject/content/entityproviders/ContentEntityProvider.java
@@ -160,12 +160,6 @@ public class ContentEntityProvider extends AbstractEntityProvider implements Ent
 	@EntityCustomAction(action="resources", viewKey=EntityView.VIEW_LIST)
 	public List<EntityContent> getResources(EntityView view, Map<String, Object> params)
 			throws EntityPermissionException {
-		String userId = developerHelperService.getCurrentUserId();
-		if (userId == null) {
-			throw new SecurityException(
-					"This action is not accessible to anon and there is no current user.");
-		}
-
 		Map<String, Object> parameters = getQueryMap((String)params.get("queryString"));
 		Time timeStamp = getTime((String)parameters.get(PARAMETER_TIMESTAMP));
 


### PR DESCRIPTION
...for non-logged in users.

Before the logic was to throw an exception if there was no logged in user - this was an issue because sometimes there is no logged in user but the site is public so we should be showing the folder listing.  

Here I'm adding logic to say throw an exception if there is no logged in user and the site is not public, i.e. carry on if there is no logged in user and the site is public.   

The check that the site is public is the same check as the one used to show the checkbox when you go to Site Info-> Manage Access (and look at the the 'Public' checkbox). 