### PR TITLE
WL-4926 Check that $ENTITYID is defined.

### DIFF
--- a/docker/apache/entrypoint.sh
+++ b/docker/apache/entrypoint.sh
@@ -6,13 +6,17 @@ set -e
 # We need this file so that we can copy the keytab file into place and set the permissions correctly before starting apache.
 
 if [ -d /opt/shibboleth ]; then
-  cp /opt/shibboleth/* /etc/shibboleth
-  # This sets the $ENTITYID value
-  envsubst < /opt/shibboleth/shibboleth2.xml > /etc/shibboleth/shibboleth2.xml
-  chown root:www-data /etc/shibboleth/*
-  chmod 644 /etc/shibboleth/*
-  # Only enable webauth if keytab is present
-  a2enmod -q shib2
+  if [ ! -z "$ENTITYID" ]; then 
+    cp /opt/shibboleth/* /etc/shibboleth
+    # This sets the $ENTITYID value in the file
+    envsubst < /opt/shibboleth/shibboleth2.xml > /etc/shibboleth/shibboleth2.xml
+    chown root:www-data /etc/shibboleth/*
+    chmod 644 /etc/shibboleth/*
+    # Only enable webauth if keytab is present
+    a2enmod -q shib2
+  else
+    echo '$ENTITYID is not set shibboleth is disabled'
+  fi
 fi
 
 (

--- a/docker/apache/shibd-entrypoint.sh
+++ b/docker/apache/shibd-entrypoint.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+if [ -z "$ENTITYID" ]; then 
+  echo '$ENTITYID is not set, not attempting to start shibd'
+  exit 1
+fi
 # Make sure permissions are correct
 chown -Rh _shibd /var/run/shibboleth
 

--- a/docker/sakai/docker-compose.yml
+++ b/docker/sakai/docker-compose.yml
@@ -32,6 +32,9 @@ services:
     # This is needed to allow jmap (heap dumps_) to work, otherwise it fails
     security_opt:
     - seccomp:unconfined
+    ports:
+      # Allow debugger to connect.
+      - "127.0.0.1:8000:8000"
     environment:
      SENTRY_DSN:
      SENTRY_ENVIRONMENT:


### PR DESCRIPTION
Both shibd and apache fall over badly when the entityId isn’t set with segmentation fails. This provides a more graceful fail. In this case Apache doesn’t load the shibboleth module and shied doesn’t attempt to start.