### PR TITLE
Fix for failure to start Apache.

### DIFF
--- a/docker/apache/entrypoint.sh
+++ b/docker/apache/entrypoint.sh
@@ -72,4 +72,8 @@ fi
 # apache2ctl would set these but we're calling apache directly to get better docker signals.
 source /etc/apache2/envvars
 
+if [ -f $APACHE_PID_FILE ] ; then
+  rm $APACHE_PID_FILE
+fi
+
 exec "$@"


### PR DESCRIPTION
Sometimes Apache would get killed and wouldn’t remove it’s PID file. This would prevent apache from starting up again and the only way to get it to start again would be to remove the container. This checks to see if the PID file is there at startup and if it is removes it.