### PR TITLE
WL-4351 Give all Oxford users a type.

### DIFF
--- a/providers/component/src/webapp/WEB-INF/jldap-beans.xml
+++ b/providers/component/src/webapp/WEB-INF/jldap-beans.xml
@@ -291,9 +291,9 @@
 		<property name="userTypeMapper">
 			<!-- Select one of the following beans -->
 			<!-- ref bean="edu.amc.sakai.user.EmptyStringUserTypeMapper" /-->
-			<ref bean="edu.amc.sakai.user.EntryAttributeToUserTypeMapper" />
+			<!--<ref bean="edu.amc.sakai.user.EntryAttributeToUserTypeMapper" />-->
 			<!-- ref bean="edu.amc.sakai.user.EntryContainerRdnToUserTypeMapper" /-->
-			<!-- ref bean="edu.amc.sakai.user.StringUserTypeMapper" /-->
+			 <ref bean="edu.amc.sakai.user.StringUserTypeMapper" />
 		</property>
 		
 	</bean>
@@ -316,10 +316,9 @@
 	<bean id="edu.amc.sakai.user.StringUserTypeMapper"
 		class="edu.amc.sakai.user.StringUserTypeMapper">
 		
-		<!--  property name="userType">
-			<value>Registered</value>
-		</property -->
-		
+		<property name="userType">
+			<value>oxford</value>
+		</property>
 	</bean>
 		
 	<!-- EntryAttributeToUserTypeMapper calculates Sakai user


### PR DESCRIPTION
To allow people to restrict signup to just Oxford users we need to first give all oxford users a type. We don’t map across any card statuses.