### PR TITLE
WL-5038 Fix BackFill Tool Job to work again.

### DIFF
--- a/jobscheduler/scheduler-component/src/webapp/WEB-INF/event-trigger.xml
+++ b/jobscheduler/scheduler-component/src/webapp/WEB-INF/event-trigger.xml
@@ -11,7 +11,7 @@
         <property name="sessionManager" ref="org.sakaiproject.tool.api.SessionManager"/>
     </bean>
 
-    <bean id="org.sakaiproject.api.app.scheduler.JobBeanWrapper.BackFillToolJob"
+    <bean id="org.sakaiproject.api.app.scheduler.JobBeanWrapper.EventTriggerJob"
           class="org.sakaiproject.component.app.scheduler.jobs.SpringConfigurableStatefulJobBeanWrapper"
           init-method="init">
         <property name="beanId">


### PR DESCRIPTION
The event trigger job had a clashing bean ID with the backfill job which meant that only one of them was getting registered.