### PR TITLE
WL-5046 Make sure logging for current-load is seen

### DIFF
--- a/current-load/src/java/uk/ac/ox/it/vle/LoadServlet.java
+++ b/current-load/src/java/uk/ac/ox/it/vle/LoadServlet.java
@@ -23,17 +23,17 @@ public class LoadServlet extends HttpServlet {
 
     private final Log log = LogFactory.getLog(LoadServlet.class);
 
-    private final int sleepLimitDefault = 5000; // Don't sleep for more than 5 seconds.
-    private final int sessionAgeDefault = 1200; // 20 minutes.
-    private final int sessionSleepDefault = 10; // Sleep for 10ms per session.
+    private final int SLEEP_LIMIT_DEFAULT = 5000; // Don't sleep for more than 5 seconds.
+    private final int SESSION_AGE_DEFAULT = 1200; // 20 minutes.
+    private final int SESSION_SLEEP_DEFAULT = 10; // Sleep for 10ms per session.
 
     private SessionManager sessionManager;
     private ServerConfigurationService serverConfigurationService;
 
     @Override
     public void init() {
-        sessionManager = (SessionManager) ComponentManager.get(SessionManager.class);
-        serverConfigurationService = (ServerConfigurationService) ComponentManager.get(ServerConfigurationService.class);
+        sessionManager = ComponentManager.get(SessionManager.class);
+        serverConfigurationService = ComponentManager.get(ServerConfigurationService.class);
     }
 
     @Override
@@ -52,7 +52,7 @@ public class LoadServlet extends HttpServlet {
 
         int delay = sessions * getSessionSleep();
         if (delay > getSleepLimit()) {
-            log.info(String.format("Sleep has become capped at: %d with %d sessions.", getSleepLimit(), sessions));
+            log.error(String.format("Sleep has become capped at: %d with %d sessions.", getSleepLimit(), sessions));
             delay = getSleepLimit();
         }
         try {
@@ -67,29 +67,24 @@ public class LoadServlet extends HttpServlet {
     }
 
     private int getSleepLimit() {
-        return getConfigInt("sleepLimitDefault", sleepLimitDefault);
+        return getConfigInt("sleepLimitDefault", SLEEP_LIMIT_DEFAULT);
     }
 
     private int getSessionAge() {
-        return getConfigInt("sessionAgeDefault", sessionAgeDefault);
+        return getConfigInt("sessionAgeDefault", SESSION_AGE_DEFAULT);
     }
 
     private int getSessionSleep() {
-        return getConfigInt("sessionSleepDefault", sessionSleepDefault);
+        return getConfigInt("sessionSleepDefault", SESSION_SLEEP_DEFAULT);
     }
 
     /**
      * Get an int from the configuration.
-     * @param value The String to convert.
+     * @param key The String to convert.
      * @param defaultValue The default value to return if it can't be converted.
      * @return The int value of a string.
      */
     int getConfigInt(String key, int defaultValue) {
-        try {
-            return serverConfigurationService.getInt("current-load."+ key, defaultValue);
-        } catch(NumberFormatException nfe) {
-            // Log exception.
-            return defaultValue;
-        }
+        return serverConfigurationService.getInt("current-load."+ key, defaultValue);
     }
 }

--- a/docker/sakai/log4j.properties
+++ b/docker/sakai/log4j.properties
@@ -39,6 +39,7 @@ log4j.logger.uk.ac.cam.caret.rwiki=INFO
 log4j.logger.org.theospi=INFO
 log4j.logger.MySQL=INFO
 log4j.logger.uk.ac.ox.oucs=INFO
+log4j.logger.uk.ac.ox.it=INFO
 log4j.logger.net.sf.snmpadaptor4j=INFO
 
 # On developer machines this maybe useful to stop seeing problems with bad DSNs


### PR DESCRIPTION
The current load servlet should log as an error when we hit the sleep
limit as we should be reconfiguring things if this is getting hit as it
means that our sessions won't be well balanced.

Also we want info logging for it.ox.ac.uk which should have got enabled
earlier. Also code tidy ups in the load servlet.