### PR TITLE
WL-3356 Upgrade to PDFBox 2.0.6 to fix font cache.

### DIFF
--- a/search/solr/impl/pom.xml
+++ b/search/solr/impl/pom.xml
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>org.apache.pdfbox</groupId>
             <artifactId>pdfbox</artifactId>
-            <scope>compile</scope>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/search/solr/impl/src/main/java/org/sakaiproject/search/producer/BinaryContentHostingContentProducer.java
+++ b/search/solr/impl/src/main/java/org/sakaiproject/search/producer/BinaryContentHostingContentProducer.java
@@ -1,6 +1,5 @@
 package org.sakaiproject.search.producer;
 
-import org.apache.pdfbox.pdmodel.font.PDFont;
 import org.apache.tika.Tika;
 import org.sakaiproject.content.api.ContentResource;
 import org.sakaiproject.search.api.StoredDigestContentProducer;
@@ -68,11 +67,6 @@ public class BinaryContentHostingContentProducer extends ContentHostingContentPr
             } catch (IOException e) {
                 logger.error("Error while closing the contentStream", e);
             }
-            // PDFont leaks memory so clear it out each time around.
-            // On a long running JVM the static internal HashMap
-            // (org.apache.pdfbox.pdmodel.font.PDFont.cmapObjects) has been seen
-            // to be eating up 750MB of heap.
-            PDFont.clearResources();
         }
     }
 

--- a/search/solr/pom.xml
+++ b/search/solr/pom.xml
@@ -81,7 +81,7 @@
         <amqp.version>3.1.1</amqp.version>
         <hamcrest.version>1.3</hamcrest.version>
         <joda-time.version>2.2</joda-time.version>
-        <pdfbox.version>1.8.6</pdfbox.version>
+        <pdfbox.version>2.0.6</pdfbox.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
This should mean that the font cache doesn’t leak memory now when indexing a large number of PDFs. This also reverts the original workaround of clearing the font cache after processing each document.