### PR TITLE
WL-5034 Fix for different versions getting installed

### DIFF
--- a/site-manage/user-picker/package.json
+++ b/site-manage/user-picker/package.json
@@ -14,13 +14,13 @@
     "lint": "eslint --ext .js,.vue src test/unit/specs test/e2e/specs"
   },
   "dependencies": {
-    "axios": "^0.16.2",
-    "bootstrap": "^3.3.7",
-    "url-search-params": "^0.10.0",
-    "url-search-params-polyfill": "^2.0.0",
-    "vue": "^2.3.4",
-    "vue-i18n": "^7.0.5",
-    "vue-router": "^2.3.1"
+    "axios": "0.16.2",
+    "bootstrap": "3.3.7",
+    "url-search-params": "0.10.0",
+    "url-search-params-polyfill": "2.0.0",
+    "vue": "2.3.4",
+    "vue-i18n": "7.0.5",
+    "vue-router": "2.3.1"
   },
   "devDependencies": {
     "autoprefixer": "^6.7.2",


### PR DESCRIPTION
A newer version of the  i18n module for due doesn’t appear to work correctly in our setup so we’re locking down all our dependencies to that this doesn’t happen again.