### PR TITLE
WL-5083 Stop emails coming from postmaster@weblearn.ox.ac.uk

### DIFF
--- a/docker/sakai/placeholder.properties
+++ b/docker/sakai/placeholder.properties
@@ -921,3 +921,8 @@ document.addEventListener("DOMContentLoaded", function(event) { \n\
 	} \n\
 }); \n\
 </script>  
+
+# This corrects the problem of emails being sent out from postmaster instead of the Oxford address.
+mail.sendfromsakai.fromtext=On behalf of {}
+mail.sendfromsakai.exceptions=.*\\.ox\\.ac\\.uk
+mail.sendfromsakai=weblearn-noreply@it.ox.ac.uk


### PR DESCRIPTION
This configures how Sakai sends out emails and sets the from address. Now we do send from *.ox.ac.uk but for everything else we continue using a email address from a non-reply address but change it to weblearn-noreply@it.ox.ac.uk