### PR TITLE
WL-5089 Correctly lookup original site ID.

### DIFF
--- a/feedback/pom.xml
+++ b/feedback/pom.xml
@@ -78,7 +78,11 @@
    		<dependency>
 			<groupId>org.sakaiproject.entitybroker</groupId>
 			<artifactId>entitybroker-api</artifactId>
-   		</dependency>
+		</dependency>
+        <dependency>
+            <groupId>org.sakaiproject.portal</groupId>
+            <artifactId>sakai-portal-api</artifactId>
+        </dependency>
    		<dependency>
 			<groupId>org.sakaiproject.entitybroker</groupId>
 			<artifactId>entitybroker-utils</artifactId>

--- a/feedback/src/java/org/sakaiproject/feedback/tool/FeedbackTool.java
+++ b/feedback/src/java/org/sakaiproject/feedback/tool/FeedbackTool.java
@@ -22,6 +22,8 @@
 package org.sakaiproject.feedback.tool;
 
 import org.apache.commons.lang.StringEscapeUtils;
+import org.sakaiproject.portal.api.PortalService;
+import org.sakaiproject.thread_local.api.ThreadLocalManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sakaiproject.authz.api.SecurityService;
@@ -57,6 +59,8 @@ public class FeedbackTool extends HttpServlet {
 
     private SiteService siteService = null;
 
+    private ThreadLocalManager threadLocalManager = null;
+
     private final String[] DYNAMIC_PROPERTIES = { "help_tooltip",  "overview", "technical_setup_instruction", "feature_suggestion_setup_instruction",
             "report_technical_tooltip", "short_technical_description",
             "suggest_feature_tooltip", "feature_description", "technical_instruction",  "error", "help_home"};
@@ -76,6 +80,7 @@ public class FeedbackTool extends HttpServlet {
             sakaiProxy = (SakaiProxy) context.getBean("org.sakaiproject.feedback.util.SakaiProxy");
             securityService = (SecurityService) context.getBean("org.sakaiproject.authz.api.SecurityService");
             siteService = (SiteService) context.getBean("org.sakaiproject.site.api.SiteService");
+            threadLocalManager = context.getBean(ThreadLocalManager.class);
 
         } catch (Throwable t) {
             throw new ServletException("Failed to initialise FeedbackTool servlet.", t);
@@ -175,9 +180,12 @@ public class FeedbackTool extends HttpServlet {
      * @return The site ID.
      */
     private String overrideSiteId(HttpServletRequest request, String siteId) {
-        if (siteId.equals("!error")) {
-            // When inside the !error site we get the URL of the original site being accessed
-            return request.getContextPath();
+        Object o = threadLocalManager.get(PortalService.SAKAI_PORTAL_ORIGINAL_SITEID);
+        if (o instanceof String) {
+            return (String)o;
+        }
+        if ("!error".equals(siteId)) {
+            return null;
         }
         return siteId;
     }

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/SkinnableCharonPortal.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/SkinnableCharonPortal.java
@@ -278,6 +278,11 @@ public class SkinnableCharonPortal extends HttpServlet implements Portal
 				String[] parts = getParts(req);
 				if (parts.length >= 3) {
 					String siteId = parts[2];
+					try {
+						// Lookup any alias in the URL
+						siteId = getSiteHelper().getSite(siteId).getId();
+					} catch (IdUnusedException ignored) {
+					}
 					ThreadLocalManager.set(PortalService.SAKAI_PORTAL_ORIGINAL_SITEID, siteId);
 				}
 				siteHandler.doGet(parts, req, res, session, "!error");


### PR DESCRIPTION
When using the contact us tool in the !error site we should look for an original site ID so that we can load the contact information from there. The also updates the portal so that when it’s handling errors it resolves any aliases into original site IDs.