### PR TITLE
WL-4918: On a public site, hyperlinks inserted via 'add content' do n…

### DIFF
--- a/lessonbuilder/components/src/java/org/sakaiproject/lessonbuildertool/model/SimplePageToolDaoImpl.java
+++ b/lessonbuilder/components/src/java/org/sakaiproject/lessonbuildertool/model/SimplePageToolDaoImpl.java
@@ -859,6 +859,8 @@ public class SimplePageToolDaoImpl extends HibernateDaoSupport implements Simple
 	}
 
 	public SimplePageLogEntry getLogEntry(String userId, long itemId, Long studentPageId) {
+		if (userId == null || userId.isEmpty())
+			userId = ".anon";
 		if(studentPageId.equals(-1L)) studentPageId = null;
 		
 		DetachedCriteria d = DetachedCriteria.forClass(SimplePageLogEntry.class).add(Restrictions.eq("userId", userId))
@@ -894,7 +896,7 @@ public class SimplePageToolDaoImpl extends HibernateDaoSupport implements Simple
 
 	    Object [] fields = new Object[2];
 	    fields[0] = Long.toString(pageId);
-	    fields[1] = userId;
+	    fields[1] = (userId == null || userId.isEmpty())? ".anon" : userId;
 	    List<String> ones = sqlService.dbRead("select 1 from lesson_builder_items a, lesson_builder_log b where a.sakaiId=? and a.type=2 and a.id=b.itemId and b.userId=?", fields, null);
 	    if (ones != null && ones.size() > 0)
 		return true;

--- a/lessonbuilder/hbm/src/java/org/sakaiproject/lessonbuildertool/SimplePageLogEntryImpl.java
+++ b/lessonbuilder/hbm/src/java/org/sakaiproject/lessonbuildertool/SimplePageLogEntryImpl.java
@@ -47,7 +47,7 @@ public class SimplePageLogEntryImpl implements SimplePageLogEntry {
 
 	public SimplePageLogEntryImpl(String userId, long itemId, Long studentPageId) {
 		firstViewed = new Date();
-		this.userId = userId;
+		this.userId = (userId == null || userId.isEmpty() ? ".anon" : userId);
 		this.itemId = itemId;
 		this.studentPageId = studentPageId;
 		complete = false;

--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/service/LessonBuilderAccessService.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/service/LessonBuilderAccessService.java
@@ -1269,8 +1269,6 @@ public class LessonBuilderAccessService {
 
     // similar to SimplePageBean.track, but doesn't need bean;
     public void track(long itemId, String userId) {
-	if (userId == null)
-	    userId = ".anon";
 	SimplePageLogEntry entry = simplePageToolDao.getLogEntry(userId, itemId, -1L);
 	// don't need a toolid for this entry. it's only used for pages
 	if (entry == null) {

--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/beans/SimplePageBean.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/beans/SimplePageBean.java
@@ -4710,8 +4710,6 @@ public class SimplePageBean {
 		}
 
 		String userId = getCurrentUserId();
-		if (userId == null)
-		    userId = ".anon";
 		SimplePageLogEntry entry = getLogEntry(itemId, studentPageId);
 		String toolId = ((ToolConfiguration) toolManager.getCurrentPlacement()).getPageId();
 		
@@ -5609,8 +5607,6 @@ public class SimplePageBean {
 		    // if no log entry, create a dummy entry
 			if (shouldHaveAccess) {
 				String userId = getCurrentUserId();
-				if (userId == null)
-					userId = ".anon";
 				SimplePageLogEntry entry = simplePageToolDao.makeLogEntry(userId, itemId, null);
 				entry.setDummy(true);
 				saveItem(entry);


### PR DESCRIPTION
…ot work for non-logged in user.


The problem here is that, when the content link in Lessons is clicked, it uses general security (rather than lessonbuilder security)  which throws an error that the user is not logged in (rather than opening up the link in a new tab).  The test it uses to decide which kind of security to use is partly whether the page has been visited by the current user,  and to check this it looks in the LESSON_BUILDER_LOG table and tries to find an entry containing the link and a null userid.  Unfortunately, the userId column is a non-null column so it is never going to find that row!  
This change is to change it so that it searches for a empty string rather than a null userId.

Nb. I initially tried passing in the empty string as one of the 2 field parameters but the semantic string parsing does not make sense to Java even if it is escaped.  

 

