### PR TITLE
WL-5093 Prevent user from clicking away when assignment attachments a…

### DIFF
--- a/assignment/assignment-tool/tool/src/webapp/css/assignment.css
+++ b/assignment/assignment-tool/tool/src/webapp/css/assignment.css
@@ -322,3 +322,7 @@ fieldset .alertMessageInline,fieldset .alertMessage {
     font-style: italic !important;
     cursor: pointer !important;
 }
+
+#confirmationDialogueMessage {
+    padding-left: 15px;
+}

--- a/assignment/assignment-tool/tool/src/webapp/js/studentViewSubmission.js
+++ b/assignment/assignment-tool/tool/src/webapp/js/studentViewSubmission.js
@@ -31,3 +31,25 @@ ASN_SVS.undoCancel = function()
 	submitPanel.style.display = "block";
 	confirmationDialogue.style.display = "none";
 };
+
+$(document).ready(function()
+{
+	var inTool = false;
+
+	window.addEventListener("click", function (event) {
+		if ($.contains(document.getElementById('addSubmissionForm'), event.target)) {
+			inTool = true;
+		}
+		else {
+			inTool = false;
+		}
+	});
+
+	window.addEventListener("beforeunload", function (event) {
+		// Add a returnValue so that a pop-up occurs if there is an attachment and the user
+		// tries to click on anything other than attachment buttons/links.
+		if ($("#attachments").length != 0 && (inTool === false)) {
+			event.returnValue = "";
+		}
+	});
+});

--- a/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_student_view_submission.vm
+++ b/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_student_view_submission.vm
@@ -783,7 +783,7 @@ $(document).ready(function(){
 											#else
 												<img src = "#imageLink($contentTypeImageService.getContentTypeImage($props.getProperty($props.NamePropContentType)))" border="0" alt="$tlang.getString("gen.filatt")" />
 											#end
-											<a href="$attachment.Url" target="_blank">$validator.escapeHtml($props.getPropertyFormatted($props.NamePropDisplayName))</a>						
+											<a href="$attachment.Url" target="_blank" id="attachments">$validator.escapeHtml($props.getPropertyFormatted($props.NamePropDisplayName))</a>						
 										</td>
 										<td>
 											#propertyDetails($props)
@@ -1133,8 +1133,8 @@ $(document).ready(function(){
                             #end
 					#end
 			</div>
-			<div id="confirmationDialogue" class="act messageInformation" style="display:none;">
-				$tlang.getString("gen.can.discard")
+			<div id="confirmationDialogue" class="act messageError" style="display:none;">
+				<span id="confirmationDialogueMessage">$tlang.getString("gen.can.discard")</span>
 				<input class="disableme" type="button" name="yes" accesskey="y" id="yes" value="$tlang.getString("gen.yes")" onclick="SPNR.disableControlsAndSpin( this, null ); ASN.submitForm( 'addSubmissionForm', 'cancel', null, null );" />
 				<input class="active" type="button" name="no" accesskey="n" id="no" value="$tlang.getString("gen.no")" onclick="ASN_SVS.undoCancel();" />
 			</div>


### PR DESCRIPTION
…re not submitted.

The closeDrawer function wasn't previously used, I've made some changes so it does return everything to the right state when removing the sites drawer.

![warning](https://user-images.githubusercontent.com/17832659/34298153-24b01360-e714-11e7-8f05-b9f936cbbd82.JPG)
