### PR TITLE
WL-5094 When anonymous don’t release marks for year

### DIFF
--- a/assignment/assignment-tool/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/assignment-tool/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -38,6 +38,8 @@ import java.text.NumberFormat;
 import java.text.ParseException;
 import java.text.RuleBasedCollator;
 import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -9966,6 +9968,13 @@ public class AssignmentAction extends PagedResourceActionII
         opts.put("instructions", assign.getInstructions());
         opts.put("assignmentContentId", assign.getReference());
         opts.put("anon", anonymous?"1":"0");
+        if (anonymous) {
+            // Turnitin stops an assignment being anonymous after the post date, so to keep the post date in future.
+            // We don't set it too far ahead because of duration limitations on class lengths.
+            Instant postTime = Instant.ofEpochMilli(dueTime.getTime());
+            postTime = postTime.plus(365, ChronoUnit.DAYS);
+            opts.put("dtpost", dform.format(postTime.toEpochMilli())); // Ensure results aren't released sooner.
+        }
 
         int factor = AssignmentService.getScaleFactor();
         int dec = (int)Math.log10(factor);

--- a/turnitin/contentreview-impl/impl/src/java/org/sakaiproject/turnitin/util/TIIFID.java
+++ b/turnitin/contentreview-impl/impl/src/java/org/sakaiproject/turnitin/util/TIIFID.java
@@ -41,7 +41,7 @@ public enum TIIFID {
             TIIParam.dis, TIIParam.dtdue, TIIParam.dtstart, TIIParam.encrypt,
             TIIParam.fcmd, TIIParam.fid, TIIParam.gmtime, TIIParam.newassign,
             TIIParam.said, TIIParam.uem, TIIParam.ufn, TIIParam.uid,
-            TIIParam.uln, TIIParam.upw, TIIParam.username, TIIParam.utp}),
+            TIIParam.uln, TIIParam.upw, TIIParam.username, TIIParam.utp, TIIParam.dtpost}),
     fid5 (5, new TIIParam[] {
             TIIParam.aid, TIIParam.assign, TIIParam.assignid, TIIParam.cid,
             TIIParam.ctl, TIIParam.diagnostic, TIIParam.dis, TIIParam.encrypt,
@@ -73,7 +73,7 @@ public enum TIIFID {
             TIIParam.dis, TIIParam.dtdue, TIIParam.dtstart, TIIParam.encrypt,
             TIIParam.fcmd, TIIParam.fid, TIIParam.gmtime, TIIParam.newassign,
             TIIParam.said, TIIParam.tem, TIIParam.uem, TIIParam.ufn, TIIParam.uid,
-            TIIParam.uln, TIIParam.upw, TIIParam.username, TIIParam.utp}),
+            TIIParam.uln, TIIParam.upw, TIIParam.username, TIIParam.utp, TIIParam.dtpost}),
     fid99 (99, new TIIParam[] {TIIParam.aid, TIIParam.diagnostic, TIIParam.encrypt,
             TIIParam.fcmd, TIIParam.fid, TIIParam.gmtime,
             TIIParam.uem, TIIParam.ufn, TIIParam.uln,TIIParam.utp});

--- a/turnitin/contentreview-impl/impl/src/java/org/sakaiproject/turnitin/util/TIIParam.java
+++ b/turnitin/contentreview-impl/impl/src/java/org/sakaiproject/turnitin/util/TIIParam.java
@@ -33,6 +33,7 @@ public enum TIIParam {
     dis,
     dtdue,
     dtstart,
+    dtpost,
     encrypt,
     fcmd,
     fid,


### PR DESCRIPTION
If an assignment in Sakai is anonymous and the submissions are being sent to Turnitin. Tell Turnitin not to release the marks/feedback for a year. This is done because when the marks are released the anonymity is removed from the Turnitin reports.

We don’t do this in the case of a non-anonymous assignment incase the instructor is providing feedback in Turnitin and we don’t want to delay feeding back for a year. The alternative would have been to expose this information in Assignments and allow the assignment creator to choose when to release the marks/anonymity.