### PR TITLE
WL-5079 Substitute test-panopto-parent-folder-id

### DIFF
--- a/basiclti/basiclti-pack/src/webapp/WEB-INF/components.xml
+++ b/basiclti/basiclti-pack/src/webapp/WEB-INF/components.xml
@@ -141,4 +141,12 @@
         <property name="ltiProperty" value="panopto-parent-folder-id"/>
     </bean>
 
+    <bean class="org.sakaiproject.lti.impl.AdminSitePropertyLookup" init-method="init" destroy-method="destroy">
+        <property name="devolvedSakaiSecurity" ref="org.sakaiproject.authz.api.DevolvedSakaiSecurity"/>
+        <property name="entityManager" ref="org.sakaiproject.entity.api.EntityManager"/>
+        <property name="ltiService" ref="org.sakaiproject.lti.api.LTIService"/>
+        <property name="sitePropery" value="test-panopto-parent-folder-id"/>
+        <property name="ltiProperty" value="test-panopto-parent-folder-id"/>
+    </bean>
+
 </beans>


### PR DESCRIPTION
This allows us to test the re-parenting code with some departments before rolling it out across the board.