### PR TITLE
WL-5114 Drop the extra backslash to fix link.

### DIFF
--- a/feedback/src/main/resources/org/sakaiproject/feedback_en_GB.properties
+++ b/feedback/src/main/resources/org/sakaiproject/feedback_en_GB.properties
@@ -4,7 +4,7 @@ overview=This page allows you to report problems with, or suggest improvements t
 help_home=If you cannot find the answer in the <a href="'{'helpPagesUrl'}'" target="'{'helpPagesTarget'}'" title="Click on this to view the {0} Help Site">Help pages</a> then please choose the most relevant section below to get in touch with the appropriate people.
 help_tooltip=Click on this to view the {0} Guidance Site
 technical_instruction=Use this page to report a technical problem with {0}, \
-or, if you cannot find the answer on the <a href=\\"/info\\" target=\\"_blank\\">{0} Guidance Site</a> \
+or, if you cannot find the answer on the <a href="/info" target="_blank">{0} Guidance Site</a> \
 or in the pop-up help (available on every page from the LHS menu), then you may ask for help in completing a task. \
 Examples of such queries include \
 <ul>\


### PR DESCRIPTION
The quotes don’t need to be escaped for the JS or for the properties file. So just leave them in the file raw.