### PR TITLE
WL-5124 Set role orders for project sites.

### DIFF
--- a/providers/component/src/webapp/WEB-INF/external-group-beans.xml
+++ b/providers/component/src/webapp/WEB-INF/external-group-beans.xml
@@ -62,6 +62,14 @@
 		<property name="externalGroupManager">
 			<ref bean="uk.ac.ox.oucs.vle.ExternalGroupManager"/>
 		</property>
+		<property name="roleOrder">
+			<list>
+				<value>maintain</value>
+				<value>contribute</value>
+				<value>access</value>
+				<value>suspended</value>
+			</list>
+		</property>
 	</bean>
 
 </beans>


### PR DESCRIPTION
By default only access and maintain roles were correctly ordered, with the contribute and suspended roles being added these should be selected in the correct order. The default role order is in the Java code. Roles earlier in the list are considered better than those after them.