### PR TITLE
WL-4994: When an iframe content item (or equiv) is returned then use …

### DIFF
--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/beans/SimplePageBean.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/beans/SimplePageBean.java
@@ -2895,7 +2895,7 @@ public class SimplePageBean {
 
 			if (i.getType() == SimplePageItem.BLTI) {
 			    if (format == null || format.trim().equals(""))
-				i.setFormat("");
+				i.setFormat("inline");
 			    else
 				i.setFormat(format);
 			    // this is redundant, but the display code uses it


### PR DESCRIPTION
…the iframe on the page.

When an external tool is added or edited in Lessons, make the default display 'inline'. 