### PR TITLE
WL-5160 Allow displayID instead of EID in LTI

### DIFF
--- a/basiclti/basiclti-api/src/java/org/sakaiproject/lti/api/LTIService.java
+++ b/basiclti/basiclti-api/src/java/org/sakaiproject/lti/api/LTIService.java
@@ -119,6 +119,7 @@ public interface LTIService extends LTISubstitutionsFilter {
             "privacy:header:fields=sendname,sendemailaddr",
             "sendname:checkbox:label=bl_sendname",
             "sendemailaddr:checkbox:label=bl_sendemailaddr",
+            "usedisplayid:checkbox:label=bl_usedisplayid",
             "services:header:fields=allowoutcomes,allowroster,allowsettings",
             "allowoutcomes:checkbox:label=bl_allowoutcomes",
             "allowroster:checkbox:label=bl_allowroster",
@@ -221,6 +222,7 @@ public interface LTIService extends LTISubstitutionsFilter {
     String LTI_ALLOWFRAMEHEIGHT = "allowframeheight";
     String LTI_SENDNAME = "sendname";
     String LTI_SENDEMAILADDR = "sendemailaddr";
+    String LTI_USEDISPLAYID = "usedisplayid";
     String LTI_ALLOWOUTCOMES = "allowoutcomes";
     String LTI_ALLOWROSTER = "allowroster";
     String LTI_ALLOWSETTINGS = "allowsettings";

--- a/basiclti/basiclti-common/src/java/org/sakaiproject/basiclti/util/SakaiBLTIUtil.java
+++ b/basiclti/basiclti-common/src/java/org/sakaiproject/basiclti/util/SakaiBLTIUtil.java
@@ -408,7 +408,15 @@ public class SakaiBLTIUtil {
 		{
 			setProperty(ltiProps,BasicLTIConstants.USER_ID,user.getId());
 			setProperty(lti2subst,LTI2Vars.USER_ID,user.getId());
-			setProperty(ltiProps,BasicLTIConstants.LIS_PERSON_SOURCEDID,user.getEid());
+			if (getInt(tool.get(LTIService.LTI_USEDISPLAYID)) == 1)
+			{
+				setProperty(ltiProps, BasicLTIConstants.LIS_PERSON_SOURCEDID, user.getDisplayId());
+			}
+			else
+			{
+				setProperty(ltiProps, BasicLTIConstants.LIS_PERSON_SOURCEDID, user.getEid());
+			}
+
 			setProperty(lti2subst,LTI2Vars.USER_USERNAME,user.getEid());
 			setProperty(lti2subst,LTI2Vars.PERSON_SOURCEDID,user.getEid());
 

--- a/basiclti/basiclti-impl/src/bundle/ltiservice.properties
+++ b/basiclti/basiclti-impl/src/bundle/ltiservice.properties
@@ -62,6 +62,7 @@ bl_debug_content=Allow debug mode to be changed
 privacy=Privacy Settings:
 bl_sendname=Send User Names to External Tool
 bl_sendemailaddr=Send Email Addresses to External Tool
+bl_usedisplayid=Use Display ID
 services=Services:
 bl_allowoutcomes=Allow External Tool to return grades
 bl_allowroster=Provide Roster to External Tool

--- a/basiclti/basiclti-portlet/src/java/org/sakaiproject/blti/ProviderServlet.java
+++ b/basiclti/basiclti-portlet/src/java/org/sakaiproject/blti/ProviderServlet.java
@@ -40,6 +40,7 @@ import net.oauth.*;
 import net.oauth.server.OAuthServlet;
 import net.oauth.signature.OAuthSignatureMethod;
 
+import org.sakaiproject.authz.api.Role;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -758,7 +759,9 @@ public class ProviderServlet extends HttpServlet {
 
         // Check user has access to this tool in this site
         if(!ToolManager.isVisible(site, toolConfig)) {
-            M_log.warn("Not allowed to access tool user_id=" + user.getId() + " site="+ site.getId() + " tool=" + tool_id);
+            Role role = site.getUserRole(user.getId());
+            String userRole = (role == null)?"unknown": role.getId();
+            M_log.warn("Not allowed to access tool user_id=" + user.getId() + " role=" + userRole + " site="+ site.getId() + " tool=" + tool_id);
             throw new LTIException( "launch.site.tool.denied", "user_id=" + user.getId() + " site="+ site.getId() + " tool=" + tool_id, null);
 
         }


### PR DESCRIPTION
Allow LTI launches to pass across the displayID instead of the EID for the lis_person_sourceid value. Changing this value for existing tools will break everything as all the users will appear different, but it’s needed to match up Canvas and WebLearn accounts.