### PR TITLE
WL-5116 Fix for bad merge.

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/ExportPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/ExportPanel.java
@@ -193,7 +193,7 @@ public class ExportPanel extends Panel {
 			if (!isCustomExport || this.includeStudentId) {
 				header.add(getString("importExport.export.csv.headers.studentId"));
 			}
-			if (isCustomExport || this.includeStudentDisplayId) {
+			if (isCustomExport && this.includeStudentDisplayId) {
 				header.add(getString("importExport.export.csv.headers.studentDisplayId"));
 			}
 			if (!isCustomExport || this.includeStudentName) {
@@ -251,7 +251,7 @@ public class ExportPanel extends Panel {
 				if (!isCustomExport || this.includeStudentId) {
 					line.add(studentGradeInfo.getStudentEid());
 				}
-				if (!isCustomExport || this.includeStudentDisplayId) {
+				if (isCustomExport && this.includeStudentDisplayId) {
 					line.add(studentGradeInfo.getStudentDisplayId());
 				}
 				if (!isCustomExport ||this.includeStudentName) {


### PR DESCRIPTION
We only want to export the display ID when it’s a custom export.