### PR TITLE
WL-5203 Include h5p resize on all pages.

### DIFF
--- a/docker/sakai/placeholder.properties
+++ b/docker/sakai/placeholder.properties
@@ -921,7 +921,8 @@ document.addEventListener("DOMContentLoaded", function(event) { \n\
 		} \n\
 	} \n\
 }); \n\
-</script>  
+</script>\n\
+<script type="text/javascript" src="https://h5p.org/sites/all/modules/h5p/library/js/h5p-resizer.js" async></script>
 
 # This corrects the problem of emails being sent out from postmaster instead of the Oxford address.
 mail.sendfromsakai.fromtext=On behalf of {}


### PR DESCRIPTION
This means all WL pages and all pages served by resources will have the h5p script included on them. The async means that it can be run in the background and doesn’t prevent the page loading if h5p is down or can’t be accessed.