### PR TITLE
WL-5199 LTI copying doesn’t need site.upd

### DIFF
--- a/basiclti/web-ifp/src/java/org/sakaiproject/portlets/SakaiIFrame.java
+++ b/basiclti/web-ifp/src/java/org/sakaiproject/portlets/SakaiIFrame.java
@@ -255,9 +255,6 @@ public class SakaiIFrame extends GenericPortlet {
 	 */
 	private Map<String, Object> patchContentItem(Long key, Placement placement)
 	{
-		// Get out tool configuration so we can fix things up...
-		ToolConfiguration toolConfig = SiteService.findTool(placement.getId());
-
 		// Look up the content item, bypassing authz checks
 		Map<String, Object> content = m_ltiService.getContentDao(key);
 		if ( content == null ) return null;
@@ -265,7 +262,8 @@ public class SakaiIFrame extends GenericPortlet {
 
 		// Look up the tool associated with the Content Item
 		// checking Authz to see is we can touch this tool
-		Map<String, Object> tool = m_ltiService.getTool(tool_id, placement.getContext());
+		String siteId = placement.getContext();
+		Map<String, Object> tool = m_ltiService.getTool(tool_id, siteId);
 		if ( tool == null ) return null;
 
 		// Now make a content item from this tool inheriting from the other content item
@@ -278,11 +276,13 @@ public class SakaiIFrame extends GenericPortlet {
 			props.put(k, value.toString());
 		}
 		props.put(LTIService.LTI_TOOL_ID, tool_id.toString());
-		props.put(LTIService.LTI_SITE_ID, placement.getContext());
+		props.put(LTIService.LTI_SITE_ID, siteId);
 		props.put(LTIService.LTI_PLACEMENT, placement.getId());
 
-		Object retval = m_ltiService.insertContent(props, placement.getContext());
-		if ( retval instanceof String ) {
+		// The current user may not be a maintainer in the current site, but we want to still be able to
+		// correct the source on the LTI tool
+		Object retval = m_ltiService.insertContentDao(props, siteId, m_ltiService.isAdmin(siteId), true);
+		if ( retval == null || retval instanceof String ) {
 			M_log.error("Unable to insert LTILinkItem tool={} placement={}",tool_id,placement.getId());
 			placement.getPlacementConfig().setProperty(SOURCE,"");
 			placement.save();
@@ -290,7 +290,7 @@ public class SakaiIFrame extends GenericPortlet {
 		}
 
 		Long contentKey = (Long) retval;
-		Map<String,Object> newContent = m_ltiService.getContent(contentKey, placement.getContext());
+		Map<String,Object> newContent = m_ltiService.getContent(contentKey, siteId);
 		String contentUrl = m_ltiService.getContentLaunch(newContent);
 		if ( newContent == null || contentUrl == null ) {
 			M_log.error("Unable to set contentUrl tool={} placement={}",tool_id,placement.getId());


### PR DESCRIPTION
In our deployment users don’t have the site.upd permission on My Workspace (My Home), this means that when they visit an LTI tool that attempts to patch it’s content it fails because they aren’t allowed to update the LTI tool.

This uses the DAO method which doesn’t do permission checks so it works for people without site.upd permission.