### PR TITLE
WL-5199 Fix so LTI tool can be stealthed.

### DIFF
--- a/basiclti/web-ifp/src/java/org/sakaiproject/portlets/SakaiIFrame.java
+++ b/basiclti/web-ifp/src/java/org/sakaiproject/portlets/SakaiIFrame.java
@@ -281,9 +281,10 @@ public class SakaiIFrame extends GenericPortlet {
 
 		// The current user may not be a maintainer in the current site, but we want to still be able to
 		// correct the source on the LTI tool
-		Object retval = m_ltiService.insertContentDao(props, siteId, m_ltiService.isAdmin(siteId), true);
+		// Also pretend that the user is an admin so they can have stealth tools patched.
+		Object retval = m_ltiService.insertContentDao(props, siteId, true, true);
 		if ( retval == null || retval instanceof String ) {
-			M_log.error("Unable to insert LTILinkItem tool={} placement={}",tool_id,placement.getId());
+			M_log.error("Unable to insert LTILinkItem tool={} placement={} retval={}",tool_id,placement.getId(), retval);
 			placement.getPlacementConfig().setProperty(SOURCE,"");
 			placement.save();
 			return null;

--- a/jobscheduler/scheduler-component-shared/src/java/org/sakaiproject/component/app/scheduler/jobs/removesites/RemoveMySitesJob.java
+++ b/jobscheduler/scheduler-component-shared/src/java/org/sakaiproject/component/app/scheduler/jobs/removesites/RemoveMySitesJob.java
@@ -1,0 +1,87 @@
+package org.sakaiproject.component.app.scheduler.jobs.removesites;
+
+
+import lombok.Setter;
+import lombok.extern.java.Log;
+import lombok.extern.slf4j.Slf4j;
+import org.quartz.Job;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.sakaiproject.exception.IdUnusedException;
+import org.sakaiproject.exception.PermissionException;
+import org.sakaiproject.javax.PagingPosition;
+import org.sakaiproject.site.api.Site;
+import org.sakaiproject.site.api.SiteService;
+import org.sakaiproject.tool.api.Session;
+import org.sakaiproject.tool.api.SessionManager;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.List;
+
+
+/**
+ * This removes all the user's sites. This is useful if you change the template and want to have all the sites
+ * re-copied from the templates.
+ */
+@Slf4j
+public class RemoveMySitesJob implements Job {
+
+    @Setter
+    private SiteService siteService;
+    @Setter
+    private SessionManager sessionManager;
+    @Setter
+    private Collection<String> ignoredSiteIds;
+
+    @Override
+    public void execute(JobExecutionContext context) throws JobExecutionException {
+
+        Session session = sessionManager.getCurrentSession();
+        try {
+            session.setUserId("admin");
+            session.setUserEid("admin");
+
+            int removed = 0;
+            // Ratio of sleep to work ( 2 = sleep twice as much as you work ), this is to prevent the job from
+            // using up all the resources
+            int workRate = 1;
+            Instant started = Instant.now();
+            Duration slept = Duration.ZERO;
+
+            // Load all in one go (but just the IDs) so we know we have them all.
+            List<String> siteIds = siteService.getSiteIds(SiteService.SelectionType.USER, null, null, null, SiteService.SortType.NONE, null);
+            siteIds.removeIf(siteId -> !siteService.isUserSite(siteId));
+            siteIds.removeAll(ignoredSiteIds);
+            for(String siteId : siteIds) {
+                try {
+                    Site site = siteService.getSite(siteId);
+                    // There's no recycle bin for user sites.
+                    siteService.removeSite(site);
+                    removed++;
+                    Duration working = Duration.between(started, Instant.now()).minus(slept);
+                    Duration pause = working.dividedBy(workRate).minus(slept);
+                    if (!pause.isNegative()) {
+                        long millis = pause.toMillis();
+                        log.debug("Sleeping for {}ms", millis);
+                        Thread.sleep(millis);
+                        slept = slept.plus(pause);
+                    }
+                } catch (IdUnusedException iue) {
+                    log.warn("Failed to find site {}, concurrent jobs running?", siteId);
+                } catch (PermissionException e) {
+                    log.error("Failed to have permission to remove site: {}", siteId);
+                } catch (InterruptedException e) {
+                    log.error("Failed to sleep because of interruption");
+                }
+            }
+            log.info("Job completed, {}/{} removed, took {} minutes",
+                removed, siteIds.size(), Duration.between(started, Instant.now()).toMinutes());
+        } finally {
+            session.clear();
+        }
+
+
+    }
+}

--- a/jobscheduler/scheduler-component/src/webapp/WEB-INF/components.xml
+++ b/jobscheduler/scheduler-component/src/webapp/WEB-INF/components.xml
@@ -426,6 +426,36 @@
       </property>
    </bean>
 
+    <!-- Remove My Workspaces -->
+    <bean id="org.sakaiproject.component.app.scheduler.jobs.removesites.RemoveMySites"
+          class="org.sakaiproject.component.app.scheduler.jobs.removesites.RemoveMySitesJob">
+        <property name="sessionManager">
+            <ref bean="org.sakaiproject.tool.api.SessionManager"/>
+        </property>
+        <property name="siteService">
+            <ref bean="org.sakaiproject.site.api.SiteService"/>
+        </property>
+        <property name="ignoredSiteIds">
+            <set>
+                <value>~admin</value>
+            </set>
+        </property>
+    </bean>
+
+    <bean id="org.sakaiproject.api.app.scheduler.JobBeanWrapper.RemoveMySites"
+          class="org.sakaiproject.component.app.scheduler.jobs.SpringJobBeanWrapper"
+          init-method="init">
+        <property name="beanId">
+            <value>org.sakaiproject.component.app.scheduler.jobs.removesites.RemoveMySites</value>
+        </property>
+        <property name="jobName">
+            <value>Remove My Workspace Sites</value>
+        </property>
+        <property name="schedulerManager">
+            <ref bean="org.sakaiproject.api.app.scheduler.SchedulerManager" />
+        </property>
+    </bean>
+
     <!-- Hide LB-CSS folder from access user-->
     <bean id = "org.sakaiproject.component.app.scheduler.jobs.LBCSSFolderHideJob"
           class="org.sakaiproject.component.app.scheduler.jobs.LBCSSFolderHideJob">

--- a/kernel/api/src/main/java/org/sakaiproject/site/api/SiteService.java
+++ b/kernel/api/src/main/java/org/sakaiproject/site/api/SiteService.java
@@ -303,6 +303,9 @@ public interface SiteService extends EntityProducer
 
 		/** Get unpublished sites the current user has access to */
 		public static final SelectionType INACTIVE_ONLY = new SelectionType("inactive", true, true, false, true);
+
+		/** Get user sites that aren't deleted */
+		public static final SelectionType USER = new SelectionType("user", true, false, false, true);
 	}
 
 	/**


### PR DESCRIPTION
Patching a tool currently fails is the current user isn’t admin and the tool is stealthed. This allows a tool to be stealthed to it can’t be added any other way, but still allows it to be patched by normal users.