### PR TITLE
WL-5227 Update to newer sentry library.

### DIFF
--- a/deploy/common/pom.xml
+++ b/deploy/common/pom.xml
@@ -27,9 +27,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.sakaiproject.sentry</groupId>
-            <artifactId>raven-sakai</artifactId>
-            <version>1.2</version>
+            <groupId>uk.ac.ox.it.sentry</groupId>
+            <artifactId>sentry-sakai</artifactId>
+            <version>1.0</version>
         </dependency>
     </dependencies>
 </project>

--- a/docker/sakai/Dockerfile
+++ b/docker/sakai/Dockerfile
@@ -26,6 +26,9 @@ RUN chmod 755 /opt/tomcat/bin/startup_with_yjp.sh
 # Up the memory for production
 ENV CATALINA_OPTS_MEMORY -Xms2g -Xmx3g
 
+# Get hostnames correctly in docker
+ENV SENTRY_FACTORY=uk.ac.ox.it.sentry.DockerSentryClientFactory
+
 # To allow de-reploy and expanding of webapps.
 RUN chown sakai /opt/tomcat/webapps
 

--- a/docker/sakai/docker-compose.yml
+++ b/docker/sakai/docker-compose.yml
@@ -37,7 +37,7 @@ services:
       - "127.0.0.1:8000:8000"
     environment:
      SENTRY_DSN:
-     SENTRY_ENVIRONMENT:
+     SENTRY_FACTORY: uk.ac.ox.it.sentry.DockerSentryClientFactory
      CATALINA_OPTS_EXTRA:
      # In development this means we can read files without anything special
      SAKAI_USER: root

--- a/docker/sakai/log4j.properties
+++ b/docker/sakai/log4j.properties
@@ -2,9 +2,7 @@ log4j.rootLogger=WARN, console, sentry, catalina
 
 # Sentry setup
 # The DSN should be supplied through the envrionment
-log4j.appender.sentry=com.getsentry.raven.log4j.SentryAppender
-# This is so that we get the correct hostname in docker
-log4j.appender.sentry.ravenFactory=org.sakaiproject.sentry.DockerRavenFactory
+log4j.appender.sentry=io.sentry.log4j.SentryAppender
 log4j.appender.sentry.Threshold=ERROR
 
 log4j.logger.org.apache.pdfbox.pdmodel.font.PDCIDFont=OFF

--- a/docker/sakai/run-test.sh
+++ b/docker/sakai/run-test.sh
@@ -38,6 +38,7 @@ services:
     environment:
      # Blank value gets copied through from local enviroment
      SENTRY_DSN:
+     SENTRY_FACTORY: uk.ac.ox.it.sentry.DockerSentryClientFactory
      RABBITMQ_URL:
      CATALINA_JMX_PORT: 5401
      DB_ENV_MYSQL_USER: sakai


### PR DESCRIPTION
The sentry library we were using is no longer supported. The additional
environmental variables are because the new library can’t be configured
using log4j as much. As a results to get the docker hostname we need
to pass in additional environmental variables.