### PR TITLE
WL-5202 Correctly pull through forename/surname.

### DIFF
--- a/reset-pass/account-validator-tool/src/java/org/sakaiproject/accountvalidator/tool/otp/AcountValidationLocator.java
+++ b/reset-pass/account-validator-tool/src/java/org/sakaiproject/accountvalidator/tool/otp/AcountValidationLocator.java
@@ -128,7 +128,9 @@ public class AcountValidationLocator implements BeanLocator  {
 			}else {
 				//find the bean
 				// always look up by token to prevent sequential guessing
-				togo = validationLogic.getVaLidationAcountBytoken(name);
+				ValidationAccount va = validationLogic.getVaLidationAcountBytoken(name);
+				updateWithUserDefaults(va);
+				togo = va;
 			}
 			if (togo != null)
 			{
@@ -137,6 +139,28 @@ public class AcountValidationLocator implements BeanLocator  {
 			delivered.put(name, togo);
 		}
 		return togo;
+	}
+
+	/**
+	 * If the user object has defaults that aren't set on the Validation Account use them.
+	 * @param va The ValidationAccount.
+	 */
+	protected void updateWithUserDefaults(ValidationAccount va) {
+		if (va != null) {
+			try {
+				// If someone has set default values on the user object use those as fallbacks
+				// The getters never return null so check if they are empty.
+				User u = userDirectoryService.getUser(EntityReference.getIdFromRef(va.getUserId()));
+				if (StringUtils.isBlank(va.getFirstName())) {
+					va.setFirstName(u.getFirstName());
+				}
+				if (StringUtils.isBlank(va.getSurname())) {
+					va.setSurname(u.getLastName());
+				}
+			} catch (UserNotDefinedException e) {
+				// Ignore
+			}
+		}
 	}
 
 	public void saveAll() {

--- a/reset-pass/account-validator-tool/src/java/org/sakaiproject/accountvalidator/tool/producers/NewUserProducer.java
+++ b/reset-pass/account-validator-tool/src/java/org/sakaiproject/accountvalidator/tool/producers/NewUserProducer.java
@@ -165,11 +165,12 @@ public class NewUserProducer extends BaseValidationProducer implements ViewCompo
 		String otp = "accountValidationLocator." + va.getValidationToken();
 		UIBranchContainer firstNameContainer = UIBranchContainer.make(detailsForm, "firstNameContainer:");
 		UIMessage.make(firstNameContainer, "lblFirstName", "firstname");
-		UIInput.make(detailsForm, "firstName", otp + ".firstName", u.getFirstName());
+		UIInput.make(detailsForm, "firstName", otp + ".firstName");
+
 		UIBranchContainer lastNameContainer = UIBranchContainer.make(detailsForm, "lastNameContainer:");
 		UIMessage.make(lastNameContainer, "lblLastName", "lastname");
-		UIInput.make(detailsForm, "surName", otp + ".surname", u.getLastName());
-		
+		UIInput.make(detailsForm, "surName", otp + ".surname");
+
 		// In terms of using UIVerbatim, we would gladly accept an alternate method of doing this, however
 		// this seems to be the only way to pass the enabled, disabled value from the server into the JavaScript
 		boolean passwordPolicyEnabled = (userDirectoryService.getPasswordPolicy() != null);


### PR DESCRIPTION
When the forename and surname were set on the user object but weren’t set on the ValidationAccount object the value would be shown in the form but then when submitted it would generate an error saying that the forename was empty.

This was because the value wasn’t set on the bean backing the form and RSF only updates values that are considered too have changed. The 2 ways this can be solved are:

  - force the UIInputs to always update the bean. This means setting `mustapply` in the producer and then the default values are re-applied to the bean when the form data is read in even though the new value and the fossil values are the same. This isn’t optimal because we’re fixing it late in the call.
  - update the ValidationAccount bean with defaults from the user object if they aren’t set on the ValidationAccount itself. This is the cleaner solution as the ValidationAccount bean correctly represents the state of the form.