### PR TITLE
WL-5239 Make Google Analytics IP anonymous

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -82,6 +82,11 @@
 #
 # portal.google.universal_analytics_id=UA-XXXXXX-XX
 
+# SAK-41039
+# Support to anonymize IP in Google Analytics, only supported by Universal Google Analytics.
+# Default: false
+# portal.google.anonymize.ip = true
+
 # SAK-29668
 # Add support for Google Tag Manager
 # Google Tag Manager is NOT enabled by default, setting these will enable it

--- a/docker/sakai/placeholder.properties
+++ b/docker/sakai/placeholder.properties
@@ -310,6 +310,7 @@ ui.service = WebLearn
 ##GOOGLE ANALYTICS:
 portal.google.analytics_id=UA-54567202-1
 portal.google.analytics_detail=true
+portal.google.anonymize.ip=true
 
 ## LOGGING:
 enabled@org.sakaiproject.log.api.LogConfigurationManager=true

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/SkinnableCharonPortal.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/SkinnableCharonPortal.java
@@ -1061,6 +1061,7 @@ public class SkinnableCharonPortal extends HttpServlet implements Portal
 		String universalAnalyticsId =  ServerConfigurationService.getString("portal.google.universal_analytics_id", null);
 		if ( universalAnalyticsId != null ) {
 			rcontext.put("googleUniversalAnalyticsId", universalAnalyticsId);
+			rcontext.put("googleAnonymizeIp", ServerConfigurationService.getBoolean("portal.google.anonymize.ip", false));
 		}
 
 		String analyticsId =  ServerConfigurationService.getString("portal.google.analytics_id", null);

--- a/portal/portal-render-engine-impl/pack/src/webapp/vm/morpheus/includeAnalytics.vm
+++ b/portal/portal-render-engine-impl/pack/src/webapp/vm/morpheus/includeAnalytics.vm
@@ -35,6 +35,7 @@
         })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
         ga('create', '${googleUniversalAnalyticsId}', { 'userId': portal.user.id });
+        ga('set', 'anonymizeIp', ${googleAnonymizeIp});
         ga('send', 'pageview');
     </script>
 


### PR DESCRIPTION
It just throws away the last octet of the IP.