### PR TITLE
WL-5243 Ignore most of the XCRI warning in the logs

### DIFF
--- a/docker/sakai/log4j.properties
+++ b/docker/sakai/log4j.properties
@@ -46,6 +46,9 @@ log4j.logger.net.sf.snmpadaptor4j=INFO
 # Ignore erroneous MyFaces warnings
 log4j.logger.org.apache.myfaces=ERROR
 
+# Ignore XCRI importing warnings
+log4j.logger.org.xcri.core=ERROR
+
 #log4j.appender.deleted=org.apache.log4j.net.SyslogAppender
 #log4j.appender.deleted.SyslogHost=localhost
 #log4j.appender.deleted.Facility=local1


### PR DESCRIPTION
These are warning that aren’t going to be addressed and so are just filling up the logs.