### PR TITLE
WL-5249 Don’t remove all the provided members.

### DIFF
--- a/site-manage/site-manage-group-section-role-helper/tool/src/java/org/sakaiproject/site/tool/helper/managegroupsectionrole/impl/SiteManageGroupSectionRoleHandler.java
+++ b/site-manage/site-manage-group-section-role-helper/tool/src/java/org/sakaiproject/site/tool/helper/managegroupsectionrole/impl/SiteManageGroupSectionRoleHandler.java
@@ -716,7 +716,12 @@ public class SiteManageGroupSectionRoleHandler {
 			for (Iterator iMembers = members.iterator(); iMembers
 					.hasNext();) {
 				found = false;
-				String mId = ((Member) iMembers.next()).getUserId();
+				Member member = (Member) iMembers.next();
+				// Don't remove all the provided ones, they will get updated when the refresh queue gets processed.
+				if (member.isProvided()) {
+					continue;
+				}
+				String mId = member.getUserId();
 				for (int i = 0; !found && i < membersSelected.length; i++)
 				{
 					if (mId.equals(membersSelected[i])) {


### PR DESCRIPTION
When updating a group’s members don’t remove all the provided members. Just leave them and then when the membership is refreshed by the AuthzGroupService all the provided members will get updated.

This does mean that if you remove a section from a group it won’t immediately update, but also means that if edit a group with just sections in it the membership doesn’t jump to zero on saving.