### PR TITLE
WL-5226 Fix the RTT to work with Tomcat 8.5.x

### DIFF
--- a/course-signup/tool/src/main/java/uk/ac/ox/oucs/vle/mvc/CourseSignupController.java
+++ b/course-signup/tool/src/main/java/uk/ac/ox/oucs/vle/mvc/CourseSignupController.java
@@ -49,7 +49,7 @@ public class CourseSignupController extends AbstractController {
 	protected ModelAndView handleRequestInternal(HttpServletRequest request,
 			 HttpServletResponse response) throws Exception {
 
-		ModelAndView modelAndView = new ModelAndView(request.getPathInfo().substring(1));
+		ModelAndView modelAndView = new ModelAndView(request.getPathInfo());
 		modelAndView.addObject("externalUser", 
 				userDirectoryService.getAnonymousUser().equals(userDirectoryService.getCurrentUser()));
 

--- a/course-signup/tool/src/main/webapp/WEB-INF/applicationContext.xml
+++ b/course-signup/tool/src/main/webapp/WEB-INF/applicationContext.xml
@@ -49,8 +49,6 @@
 	
 	<bean id="viewResolver"
 		class="org.springframework.web.servlet.view.UrlBasedViewResolver">
-		
-		<property name="prefix" value="/"/>
 		<property name="viewClass" value="org.springframework.web.servlet.view.JstlView"/>
 	</bean>
 


### PR DESCRIPTION
We were attempting to use a request dispatcher to forward the request to //rest//search/.... and this was returning a 404. The problem was the double slash at the start of the path. This appeared to “work” under earlier versions of Tomcat.

This was happening because the Spring view resolver was prepending "/" to all views. The fix was to stop doing this and to stop trimming off the leading slash in the controller to generate the view.