### PR TITLE
WL-5227 Mark which frames are considered in-app

### DIFF
--- a/docker/sakai/Dockerfile
+++ b/docker/sakai/Dockerfile
@@ -28,6 +28,7 @@ ENV CATALINA_OPTS_MEMORY -Xms2g -Xmx3g
 
 # Get hostnames correctly in docker
 ENV SENTRY_FACTORY=uk.ac.ox.it.sentry.DockerSentryClientFactory
+ENV SENTRY_STACKTRACE_APP_PACKAGES=org.sakaiproject,uk.ac.ox
 
 # To allow de-reploy and expanding of webapps.
 RUN chown sakai /opt/tomcat/webapps

--- a/docker/sakai/docker-compose.yml
+++ b/docker/sakai/docker-compose.yml
@@ -38,6 +38,7 @@ services:
     environment:
      SENTRY_DSN:
      SENTRY_FACTORY: uk.ac.ox.it.sentry.DockerSentryClientFactory
+     SENTRY_STACKTRACE_APP_PACKAGES: org.sakaiproject,uk.ac.ox
      CATALINA_OPTS_EXTRA:
      # In development this means we can read files without anything special
      SAKAI_USER: root


### PR DESCRIPTION
Make it clearer which frames inside the app are considered our. This may also help with a startup deadlock, although confirming that this helps the issue is hard.