### PR TITLE
WL-5244 Prevent browser downloading inline video.

### DIFF
--- a/docker/sakai/placeholder.properties
+++ b/docker/sakai/placeholder.properties
@@ -581,6 +581,9 @@ poh.allow.disable=false
 # WL-1091 Serve XHTML correctly (inline).
 content.mime.inline.count=1
 content.mime.inline.1=application/xhtml+xml
+content.mime.inline.2=video/webm
+content.mime.inline.3=audio/mpeg
+content.mime.inline.4=video/mp4
 
 # WL-658 Setup My Workspace quota
 # 100MB for sites by default (My Workspace)


### PR DESCRIPTION
Chrome would ask the user where to save the video when it was embedded in the page. This allows it to always be displayed inline.