### PR TITLE
WL-5279 Only pop the advisor we pushed.

### DIFF
--- a/assignment/assignment-tool/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/assignment-tool/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -1296,8 +1296,8 @@ public class AssignmentAction extends PagedResourceActionII
 			
 			rv = AssignmentService.getAssignment(assignmentId);
 			
-			m_securityService.popAdvisor(contentAdvisor);
-			m_securityService.popAdvisor(secAdv);
+			popSecurityAdvisor(contentAdvisor);
+			popSecurityAdvisor(secAdv);
 		}
 		catch (IdUnusedException e)
 		{
@@ -2184,6 +2184,16 @@ public class AssignmentAction extends PagedResourceActionII
 				session.removeAttribute(sessionKey);
 		}
 		return asgnAdvisor;
+	}
+
+	/**
+	 * Removes a security advisor from the stack.
+	 * @param advisor The security advisor to remove, if <code>null</code> don't remove anything.
+	 */
+	private void popSecurityAdvisor(SecurityAdvisor advisor) {
+		if (advisor != null) {
+			m_securityService.popAdvisor(advisor);
+		}
 	}
 	
 	/**


### PR DESCRIPTION
An error was being caused when an advisor was removed from the stack that shouldn’t have been and then calling code blew up when it attempted to remove its own advisor. Now we only remove advisors we pushed.