### PR TITLE
WL-5273 Leave the Update Item for Calendar.

### DIFF
--- a/lessonbuilder/tool/src/webapp/js/show-page.js
+++ b/lessonbuilder/tool/src/webapp/js/show-page.js
@@ -509,7 +509,6 @@ $(document).ready(function() {
 			$("#resource-group-inherited").hide();
 			$("#assignment-points").hide();
 			$("#assignment-points-label").hide();
-			$("#edit-item").hide();
 			$("#name").val("Calendar");
 			$("#description").val($("#calendar-descrip").text());
 			$("#item-id").val(row.find(".calendar-item-id").text());


### PR DESCRIPTION
Although the update item for the Calendar doesn’t really work well, when it gets removed it then means that the update item remains missing for other items in the page that use the same HTML template.

Refreshing the page fixes it.