### PR TITLE
WL-445 Disable users present and neochat.

### DIFF
--- a/docker/sakai/placeholder.properties
+++ b/docker/sakai/placeholder.properties
@@ -201,6 +201,15 @@ inactiveInterval@org.sakaiproject.tool.api.SessionManager=14400
 # presence expires if not refreshed in this many seconds
 timeoutSeconds@org.sakaiproject.presence.api.PresenceService=60
 
+# Disable users present for GDPR reasons
+display.users.present=false
+
+# Still log the events though
+presence.events.log=true
+
+# Disable chat as well
+portal.neochat=false
+
 ## enable iCal import/export
 ical.experimental=true
 


### PR DESCRIPTION
This is so that we don’t leak details of people using the site to other people using the site. This should keep sitestats tracking site visits correctly.