### PR TITLE
Fix for the build stalling.

### DIFF
--- a/search/solr/impl/pom.xml
+++ b/search/solr/impl/pom.xml
@@ -11,6 +11,21 @@
     <artifactId>solr-impl</artifactId>
     <name>Sakai search - Solr impl</name>
 
+
+    <repositories>
+        <!-- The tika-parsers dependency is pulling in lots of other repositories and this one isn't responding -->
+        <repository>
+            <id>mvmsearch</id>
+            <url>http://www.mvnsearch.org/maven2/</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
     <dependencies>
         <!-- Dependencies -->
         <dependency>
@@ -26,6 +41,7 @@
             <groupId>org.apache.tika</groupId>
             <artifactId>tika-core</artifactId>
         </dependency>
+        <!-- This causes the request to mvnsearch -->
         <dependency>
             <groupId>org.apache.tika</groupId>
             <artifactId>tika-parsers</artifactId>


### PR DESCRIPTION
The tika-parsers dependency was causing maven to want to contact mvnsearch repository and this currently appears to be down. This attempt was being made for every build and the timeout is long.

This just tells maven to not use the specified repository for releases or snapshots. The ID on the repository has to match that defined in the transitive dependency.