### PR TITLE
WL-5297 Disable re-submission option on some sites

### DIFF
--- a/assignment/assignment-tool/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/assignment-tool/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -2572,6 +2572,8 @@ public class AssignmentAction extends PagedResourceActionII
 
                 context.put("group_submissions_enabled", Boolean.valueOf(ServerConfigurationService.getBoolean("assignment.group.submission.enabled", true)));
 		context.put("visible_date_enabled", Boolean.valueOf(ServerConfigurationService.getBoolean("assignment.visible.date.enabled", false)));
+
+		context.put("allow_resubmissions", isAllowResubmissions(state));
 			
 		String sortedBy = (String) state.getAttribute(SORTED_BY);
 		String sortedAsc = (String) state.getAttribute(SORTED_ASC);
@@ -2582,6 +2584,21 @@ public class AssignmentAction extends PagedResourceActionII
 		return template + TEMPLATE_INSTRUCTOR_NEW_EDIT_ASSIGNMENT;
 
 	} // build_instructor_new_assignment_context
+
+	private Boolean isAllowResubmissions(SessionState state) {
+		try {
+			Site site = SiteService.getSite((String) state.getAttribute(STATE_CONTEXT_STRING));
+			String[] types = ServerConfigurationService.getStrings("assignments.block.resubmission.site.types");
+			if (types != null) {
+				if (Arrays.asList(types).contains(site.getType())) {
+					return false;
+				}
+			}
+		} catch (IdUnusedException e) {
+			M_log.debug("Failed to find site to see if anonymous submissions are allowed.");
+		}
+		return true;
+	}
 
 	protected void setAssignmentFormContext(SessionState state, Context context)
 	{
@@ -3486,6 +3503,8 @@ public class AssignmentAction extends PagedResourceActionII
 		context.put("instructorAttachments", state.getAttribute(ATTACHMENTS));
 		context.put("contentTypeImageService", state.getAttribute(STATE_CONTENT_TYPE_IMAGE_SERVICE));
 		context.put("service", AssignmentService.getInstance());
+		context.put("allow_resubmissions", isAllowResubmissions(state));
+
 
 		// names
 		context.put("name_grade_assignment_id", GRADE_SUBMISSION_ASSIGNMENT_ID);

--- a/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_instructor_grading_submission.vm
+++ b/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_instructor_grading_submission.vm
@@ -769,7 +769,7 @@
 							#set($resubmitStyle="display:none")
 						#end
 						<div class="form-group" id="tempAllowRes" #if ($submissionType == 4) style = "display:none"#end>
-							<input type="checkbox" id="allowResToggle" name ="allowResToggle" #if($!value_allowResubmitNumber && $submissionType != 4) checked="checked"#end onclick="if(checked){document.getElementById('allowResubmitContainer').style.display = 'block';ASN.resizeFrame();}else{document.getElementById('allowResubmitContainer').style.display = 'none';}" />
+							<input #if(!$allow_resubmissions)disabled#end type="checkbox" id="allowResToggle" name ="allowResToggle" #if($!value_allowResubmitNumber && $submissionType != 4) checked="checked"#end onclick="if(checked){document.getElementById('allowResubmitContainer').style.display = 'block';ASN.resizeFrame();}else{document.getElementById('allowResubmitContainer').style.display = 'none';}" />
 							<label for="allowResToggle">$tlang.getString("allowResubmit")</label>
 	    				</div>
 						<div id="allowResubmitContainer" style="$!resubmitStyle">

--- a/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_instructor_new_edit_assignment.vm
+++ b/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_instructor_new_edit_assignment.vm
@@ -369,7 +369,7 @@
 			</label>
 			<div class="col-sm-10">
 				<div id="tempAllowRes" #if ($value_SubmissionType == 4) style = "display:none"#end>
-					<input type="checkbox" id="allowResToggle" name ="allowResToggle" #if($!value_allowResubmitNumber) checked="checked"#end onclick="if(checked){document.getElementById('allowResubmitNumber').style.display = 'block';document.getElementById('allowResubmitTime').style.display = 'block';document.getElementById('resubmitNotification').style.display = 'block';ASN.resizeFrame();}else{document.getElementById('allowResubmitNumber').style.display = 'none';document.getElementById('allowResubmitTime').style.display = 'none';document.getElementById('resubmitNotification').style.display = 'none';}" />
+					<input #if(!$allow_resubmissions)disabled#end type="checkbox" id="allowResToggle" name ="allowResToggle" #if($!value_allowResubmitNumber) checked="checked"#end onclick="if(checked){document.getElementById('allowResubmitNumber').style.display = 'block';document.getElementById('allowResubmitTime').style.display = 'block';document.getElementById('resubmitNotification').style.display = 'block';ASN.resizeFrame();}else{document.getElementById('allowResubmitNumber').style.display = 'none';document.getElementById('allowResubmitTime').style.display = 'none';document.getElementById('resubmitNotification').style.display = 'none';}" />
 				</div>
 			</div>
 		</div>

--- a/docker/sakai/placeholder.properties
+++ b/docker/sakai/placeholder.properties
@@ -938,3 +938,6 @@ document.addEventListener("DOMContentLoaded", function(event) { \n\
 mail.sendfromsakai.fromtext=On behalf of {}
 mail.sendfromsakai.exceptions=.*\\.ox\\.ac\\.uk
 mail.sendfromsakai=weblearn-noreply@it.ox.ac.uk
+
+# Any of these site types don't allow re-submissions to be enabled.
+assignments.block.resubmission.site.types=submission


### PR DESCRIPTION
The submission sites (that are used for formal submissions) shouldn’t allow resubmissions to be enabled on an assignment as there is a formal process when a student wishes to re-submit.

We just disable the UI here and so while it’s technically possible for someone to use chrome devtools to get around this I don’t think it’s worth doing a fix for that.