### PR TITLE
WL-5299 Allow admin site to be set at site creation

### DIFF
--- a/entitybroker/core-providers/src/java/org/sakaiproject/entitybroker/providers/SiteEntityProvider.java
+++ b/entitybroker/core-providers/src/java/org/sakaiproject/entitybroker/providers/SiteEntityProvider.java
@@ -693,6 +693,7 @@ RESTful, ActionsExecutable, Redirectable, RequestStorable, DepthLimitable {
 
     public String createEntity(EntityReference ref, Object entity, Map<String, Object> params) {
         String siteId = null;
+        Object adminRealm = (params != null)?params.get("adminRealm"):null;
         if (ref.getId() != null && ref.getId().length() > 0) {
             siteId = ref.getId();
         }
@@ -716,7 +717,11 @@ RESTful, ActionsExecutable, Redirectable, RequestStorable, DepthLimitable {
 
             Site s = null;
             try {
-                s = siteService.addSite(siteId, site.getType());
+                if (adminRealm instanceof String) {
+                    s = siteService.addSite(siteId, site.getType(), (String)adminRealm);
+                } else {
+                    s = siteService.addSite(siteId, site.getType());
+                }
                 s.setCustomPageOrdered(site.isCustomPageOrdered());
                 s.setDescription(description);
                 s.setIconUrl(site.getIconUrl());
@@ -786,7 +791,11 @@ RESTful, ActionsExecutable, Redirectable, RequestStorable, DepthLimitable {
 
             Site s = null;
             try {
-                s = siteService.addSite(siteId, site.getType());
+                if (adminRealm instanceof String) {
+                    s = siteService.addSite(siteId, site.getType(), (String)adminRealm);
+                } else {
+                    s = siteService.addSite(siteId, site.getType());
+                }
                 s.setCustomPageOrdered(site.isCustomPageOrdered());
                 s.setDescription(description);
                 s.setIconUrl(site.getIconUrl());

--- a/entitybroker/core-providers/src/java/site.properties
+++ b/entitybroker/core-providers/src/java/site.properties
@@ -1,7 +1,8 @@
 # this defines the entity description for site
 site = Represents a site (a collection of users and tools) in the Sakai system
 site.view.new = Adding a site will always set the owner/created by to the current user unless 'owner' is set to a userId, \
-the minimum to create a site is the id and the type, all other fields are optional
+the minimum to create a site is the id and the type, all other fields are optional. \
+If the parameter 'adminSite' is passed and is a reference to an admin site then the site will be created with the admin site set, (eg '?adminSite=/site/example-admin')
 site.view.list = Retrieves the list of all sites that the current user can access. Supply a value for '_limit' to specify \
 how many sites should be returned. Note that there is a system maximum that will override a specified value if it is larger than allowed. \
 Supply a value for '_start' to page through results in multiple requests. For example, with 42 sites, requests with '_start' = 1, '_limit' = 50 \

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/site/impl/BaseSiteService.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/site/impl/BaseSiteService.java
@@ -63,6 +63,8 @@ import java.util.*;
 import java.util.concurrent.CopyOnWriteArraySet;
 import org.sakaiproject.component.cover.ComponentManager;
 
+import static org.sakaiproject.authz.api.DevolvedSakaiSecurity.ADMIN_REALM_PERMISSION_USE;
+
 /**
  * <p>
  * BaseSiteService is a base implementation of the SiteService.
@@ -1255,6 +1257,11 @@ public abstract class BaseSiteService implements SiteService, Observer
  		}
  		else 
  		{
+ 			// Check early to see if the user can use the admin realm
+			if (!devolvedSakaiSecurity().canUseAdminRealm(adminRealm)) {
+				User user = userDirectoryService().getCurrentUser();
+				throw new PermissionException(user.getId(), ADMIN_REALM_PERMISSION_USE, adminRealm);
+			}
  			unlock(SECURE_ADD_SITE_MANAGED, siteReference(id));
  		}
 


### PR DESCRIPTION
This allows a entity broker call to create a new site and set the admin site at the same time.