### PR TITLE
WL-5305 Enable the option to have flat download

### DIFF
--- a/docker/sakai/placeholder.properties
+++ b/docker/sakai/placeholder.properties
@@ -871,6 +871,10 @@ msg.displayEid=false
 
 assignment.visible.date.enabled=true
 
+# Allow all the attachments to be at the toplevel of the zipfile
+# This means you can't upload the ZIP again, but makes browsing of submissions easier.
+assignment.download.flat=true
+
 # WL-4218 Setup defaults for the content review
 contentreview.site.years=6
 contentreview.site.min=2


### PR DESCRIPTION
This means that rather than having a folder for each student all the submissions are just put in the top-level folder.