### PR TITLE
WL-5306 Increase the site title limit

### DIFF
--- a/docker/sakai/placeholder.properties
+++ b/docker/sakai/placeholder.properties
@@ -176,7 +176,7 @@ invalidEmailInIdAccountString=ox.ac.uk,oxford.ac.uk
 nonOfficialAccountInstru=If you don't yet have an account a separate email will be sent containing your username and password.  If you haven't received this email, you can generate a new password here: https://weblearn.ox.ac.uk/portal/hierarchy/!reset-password.
 
 # Limit Site Title
-site.title.maxlength=30
+site.title.maxlength=75
 
 # Site types that worksite setup will allow you to create
 site.types=project


### PR DESCRIPTION
Increase the site title limit to 75 to allow for the remote exams site titles which are way more than the current 30 character limit.