### PR TITLE
WL-5312 Change wording on assignment not started

### DIFF
--- a/assignment/assignment-bundles/resources/assignment.properties
+++ b/assignment/assignment-bundles/resources/assignment.properties
@@ -172,7 +172,7 @@ gen.nograd        = No Grade
 gen.notavail      = This assignment is not available; Status: {0}<br>
 gen.notope        = Not Open
 gen.notset        = Not Set
-gen.notsta        = Not Started
+gen.notsta        = Not Submitted
 gen.of            = of
 gen.open          = Open
 gen.orisub        = Original submission text
@@ -1035,7 +1035,7 @@ grades.late=Late submission
 grades.lateness.late=Late
 grades.lateness.ontime=On time
 grades.lateness.unknown=Unknown
- 
+
 cr.notprocess.warning = You have uploaded a file with an extension that will not be processed by the content review service
 cr.size.warning = You have uploaded a file which size is too big for the content review service
 submission.inline=Inline Submission


### PR DESCRIPTION
The “not started” wording confused students as they thought they hadn’t started the exam yet and so instead we change to say not submitted to show that they haven’t yet submitted the assignment.