### PR TITLE
Spring version upgrade to the latest 4.x series.

### DIFF
--- a/master/pom.xml
+++ b/master/pom.xml
@@ -109,10 +109,10 @@
     <sakai.asm.version>4.1</sakai.asm.version>
     <sakai.spring.groupId>org.springframework</sakai.spring.groupId>
     <sakai.spring.artifactId>spring-core</sakai.spring.artifactId>
-    <sakai.spring.version>4.2.7.RELEASE</sakai.spring.version>
+    <sakai.spring.version>4.3.29.RELEASE</sakai.spring.version>
     <sakai.spring.security.version>3.2.9.RELEASE</sakai.spring.security.version>
     <sakai.spring.test.artifactId>spring-test</sakai.spring.test.artifactId>
-    <sakai.spring.test.version>4.1.9.RELEASE</sakai.spring.test.version>
+    <sakai.spring.test.version>4.3.29.RELEASE</sakai.spring.test.version>
     <sakai.tika.version>1.24.1</sakai.tika.version>
     <sakai.tomcat.version>8.0.20</sakai.tomcat.version>
     <sakai.velocity.version>1.6.4</sakai.velocity.version>

--- a/master/pom.xml
+++ b/master/pom.xml
@@ -110,7 +110,7 @@
     <sakai.spring.groupId>org.springframework</sakai.spring.groupId>
     <sakai.spring.artifactId>spring-core</sakai.spring.artifactId>
     <sakai.spring.version>4.3.29.RELEASE</sakai.spring.version>
-    <sakai.spring.security.version>3.2.9.RELEASE</sakai.spring.security.version>
+    <sakai.spring.security.version>4.2.19.RELEASE</sakai.spring.security.version>
     <sakai.spring.test.artifactId>spring-test</sakai.spring.test.artifactId>
     <sakai.spring.test.version>4.3.29.RELEASE</sakai.spring.test.version>
     <sakai.tika.version>1.24.1</sakai.tika.version>

--- a/master/pom.xml
+++ b/master/pom.xml
@@ -114,7 +114,7 @@
     <sakai.spring.test.artifactId>spring-test</sakai.spring.test.artifactId>
     <sakai.spring.test.version>4.3.29.RELEASE</sakai.spring.test.version>
     <sakai.tika.version>1.24.1</sakai.tika.version>
-    <sakai.tomcat.version>8.0.20</sakai.tomcat.version>
+    <sakai.tomcat.version>8.0.53</sakai.tomcat.version>
     <sakai.velocity.version>1.6.4</sakai.velocity.version>
     <sakai.xerces.impl.version>2.11.0</sakai.xerces.impl.version>
     <sakai.xerces.api.version>2.6.2</sakai.xerces.api.version>


### PR DESCRIPTION
@nicholaswilson100 I've started this initiative to patch Spring to the latest, the current Spring version is vulnerable to several security issues and I think we could think about an upgrade.

I've performed basic tests in all WebLearn tools, applying this upgrade in combination with #604 and #605, including all the previous security changes, in a first impression WebLearn works fine, starts up with a clean log and all the tools render properly.

I understand this work requires more discussion like #604 and #605, let's talk about it.

Regards and thanks.