### PR TITLE
SAK-31768 - Upgrade JavaMail from 1.4.5 to 1.6.2

### DIFF
--- a/delegatedaccess/impl/pom.xml
+++ b/delegatedaccess/impl/pom.xml
@@ -75,8 +75,8 @@
             <artifactId>commons-configuration</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.mail</groupId>
-            <artifactId>mail</artifactId>
+            <groupId>com.sun.mail</groupId>
+            <artifactId>javax.mail</artifactId>
         </dependency>
     </dependencies>
 

--- a/entitybroker/core-providers/pom.xml
+++ b/entitybroker/core-providers/pom.xml
@@ -49,8 +49,8 @@
             <artifactId>servlet-api</artifactId>
         </dependency>
          <dependency>
-            <groupId>javax.mail</groupId>
-            <artifactId>mail</artifactId>
+            <groupId>com.sun.mail</groupId>
+            <artifactId>javax.mail</artifactId>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.jaxrs</groupId>

--- a/entitybroker/impl/pom.xml
+++ b/entitybroker/impl/pom.xml
@@ -54,8 +54,8 @@
             <artifactId>spring-jdbc</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.mail</groupId>
-            <artifactId>mail</artifactId>
+            <groupId>com.sun.mail</groupId>
+            <artifactId>javax.mail</artifactId>
         </dependency>
         <!-- generic DAO -->
         <dependency>

--- a/evaluations/impl/pom.xml
+++ b/evaluations/impl/pom.xml
@@ -98,8 +98,8 @@
 
         <!-- email dependencies -->
         <dependency>
-            <groupId>javax.mail</groupId>
-            <artifactId>mail</artifactId>
+            <groupId>com.sun.mail</groupId>
+            <artifactId>javax.mail</artifactId>
         </dependency>
 
         <!-- JDOM dependencies -->

--- a/feedback/pom.xml
+++ b/feedback/pom.xml
@@ -112,8 +112,8 @@
             <artifactId>activation</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.mail</groupId>
-            <artifactId>mail</artifactId>
+            <groupId>com.sun.mail</groupId>
+            <artifactId>javax.mail</artifactId>
         </dependency>
         <!-- This doesn't have good support for testing but it's dependencies are small and API is ok.-->
         <dependency>

--- a/kernel/api/pom.xml
+++ b/kernel/api/pom.xml
@@ -56,8 +56,8 @@
       <artifactId>HikariCP</artifactId>
     </dependency>
     <dependency>
-      <groupId>javax.mail</groupId>
-      <artifactId>mail</artifactId>
+      <groupId>com.sun.mail</groupId>
+      <artifactId>javax.mail</artifactId>
     </dependency>
     <!-- UNUSED
     <dependency>

--- a/kernel/deploy/shared/pom.xml
+++ b/kernel/deploy/shared/pom.xml
@@ -189,8 +189,8 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>javax.mail</groupId>
-            <artifactId>mail</artifactId>
+            <groupId>com.sun.mail</groupId>
+            <artifactId>javax.mail</artifactId>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/kernel/kernel-impl/pom.xml
+++ b/kernel/kernel-impl/pom.xml
@@ -199,8 +199,8 @@
         <version>0.9.19</version>
     </dependency>
     <dependency>
-      <groupId>javax.mail</groupId>
-      <artifactId>mail</artifactId>
+      <groupId>com.sun.mail</groupId>
+      <artifactId>javax.mail</artifactId>
     </dependency>
     <dependency>
       <groupId>javax.activation</groupId>

--- a/kernel/kernel-util/pom.xml
+++ b/kernel/kernel-util/pom.xml
@@ -58,8 +58,8 @@
       <artifactId>spring-web</artifactId>
     </dependency>
     <dependency>
-      <groupId>javax.mail</groupId>
-      <artifactId>mail</artifactId>
+      <groupId>com.sun.mail</groupId>
+      <artifactId>javax.mail</artifactId>
     </dependency>
     <dependency>
       <groupId>commons-codec</groupId>

--- a/mailarchive/mailarchive-impl/impl/pom.xml
+++ b/mailarchive/mailarchive-impl/impl/pom.xml
@@ -65,8 +65,8 @@
             <artifactId>servlet-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.mail</groupId>
-            <artifactId>mail</artifactId>
+            <groupId>com.sun.mail</groupId>
+            <artifactId>javax.mail</artifactId>
         </dependency>
     </dependencies>
 

--- a/mailarchive/mailarchive-subetha/pom.xml
+++ b/mailarchive/mailarchive-subetha/pom.xml
@@ -50,8 +50,8 @@
             <version>3.1.7</version>
         </dependency>
         <dependency>
-            <groupId>javax.mail</groupId>
-            <artifactId>mail</artifactId>
+            <groupId>com.sun.mail</groupId>
+            <artifactId>javax.mail</artifactId>
         </dependency>
         <dependency>
             <groupId>commons-lang</groupId>

--- a/mailsender/impl/pom.xml
+++ b/mailsender/impl/pom.xml
@@ -46,17 +46,8 @@
 
         <!-- java mail -->
         <dependency>
-            <groupId>javax.activation</groupId>
-            <artifactId>activation</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>javax.mail</groupId>
-            <artifactId>mail</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-email</artifactId>
-            <version>1.2</version>
+            <groupId>com.sun.mail</groupId>
+            <artifactId>javax.mail</artifactId>
         </dependency>
 
         <!-- internal -->

--- a/master/pom.xml
+++ b/master/pom.xml
@@ -655,8 +655,8 @@
         <scope>provided</scope>
         <exclusions>
           <exclusion>
-            <groupId>javax.mail</groupId>
-            <artifactId>mail</artifactId>
+            <groupId>com.sun.mail</groupId>
+            <artifactId>javax.mail</artifactId>
           </exclusion>
           <exclusion>
             <groupId>javax.jms</groupId>
@@ -778,9 +778,9 @@
         <scope>provided</scope>
       </dependency>
       <dependency>
-        <groupId>javax.mail</groupId>
-        <artifactId>mail</artifactId>
-        <version>1.4.5</version>
+        <groupId>com.sun.mail</groupId>
+        <artifactId>javax.mail</artifactId>
+        <version>1.6.2</version>
         <scope>provided</scope>
       </dependency>
       <dependency>

--- a/msgcntr/messageforums-component-impl/pom.xml
+++ b/msgcntr/messageforums-component-impl/pom.xml
@@ -86,8 +86,8 @@
       <artifactId>commons-codec</artifactId>
     </dependency>
     <dependency>
-        <groupId>javax.mail</groupId>
-        <artifactId>mail</artifactId>
+        <groupId>com.sun.mail</groupId>
+        <artifactId>javax.mail</artifactId>
     </dependency>
     <dependency>
     	<groupId>org.sakaiproject.search</groupId>

--- a/reset-pass/account-validator-impl/pom.xml
+++ b/reset-pass/account-validator-impl/pom.xml
@@ -33,8 +33,8 @@
 
 	  <!-- email dependencies -->
 		<dependency>
-			<groupId>javax.mail</groupId>
-			<artifactId>mail</artifactId>
+			<groupId>com.sun.mail</groupId>
+			<artifactId>javax.mail</artifactId>
 		</dependency>
 
       <!-- generic DAO -->

--- a/samigo/samigo-app/pom.xml
+++ b/samigo/samigo-app/pom.xml
@@ -152,8 +152,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.mail</groupId>
-            <artifactId>mail</artifactId>
+            <groupId>com.sun.mail</groupId>
+            <artifactId>javax.mail</artifactId>
         </dependency>
 	<dependency>
             <groupId>javax.servlet.jsp</groupId>

--- a/samigo/samigo-impl/pom.xml
+++ b/samigo/samigo-impl/pom.xml
@@ -63,8 +63,8 @@
             <artifactId>servlet-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.mail</groupId>
-            <artifactId>mail</artifactId>
+            <groupId>com.sun.mail</groupId>
+            <artifactId>javax.mail</artifactId>
         </dependency>
         <dependency>
             <groupId>jdom</groupId>


### PR DESCRIPTION
The current Java Mail library is from 2012! 

I think it could be good to upgrade it to a newer version, I upgraded it locally and tested all the modules with a FakeSMTP server, it's working fine, this is an example of the SMTP debug:

`
DEBUG: JavaMail version 1.6.2
DEBUG: successfully loaded resource: /META-INF/javamail.default.address.map
DEBUG: getProvider() returning javax.mail.Provider[TRANSPORT,smtp,com.sun.mail.smtp.SMTPTransport,Oracle]
DEBUG SMTP: useEhlo true, useAuth false
DEBUG SMTP: trying to connect to host "localhost", port 25, isSSL false
220 host.docker.internal ESMTP SubEthaSMTP null
DEBUG SMTP: connected to host "localhost", port: 25
EHLO host.docker.internal
250-host.docker.internal
250-8BITMIME
250-AUTH LOGIN
250 Ok
DEBUG SMTP: Found extension "8BITMIME", arg ""
DEBUG SMTP: Found extension "AUTH", arg "LOGIN"
DEBUG SMTP: Found extension "Ok", arg ""
DEBUG SMTP: use8bit false
MAIL FROM:<weblearn-noreply@it.ox.ac.uk>
250 Ok
DEBUG SMTP: sendPartial set
RCPT TO:<mm@mm.com>
250 Ok
RCPT TO:<mm2@mm.com>
250 Ok
DEBUG SMTP: Verified Addresses
DEBUG SMTP:   mm@mm.com
DEBUG SMTP:   mm2@mm.com
DATA
354 End data with <CR><LF>.<CR><LF>
Date: Fri, 16 Oct 2020 11:27:59 +0200 (CEST)
From: "On behalf of admin@weblearn.uk" <weblearn-noreply@it.ox.ac.uk>
Reply-To: admin@weblearn.uk
Message-ID: <811083540.1.1602840479163@host.docker.internal>
Subject: TESTING THE LIBRARY :DDD
MIME-Version: 1.0
Content-Transfer-Encoding: 7bit
Content-Type: text/html; charset=utf-8

<p>----------------------<br>This forwarded message was sent via WebLearn Messages from the  "TESTING_SITE" site.
To reply to this message click this link to access Messages for this site: <a href="http://localhost:8080/portal/site/40e7e610-dc90-4c61-aab6-7b91dc712619/page/315e2be1-0cdc-435b-883f-fab5f984d0af">TESTING_SITE</a><br>----------------------</p><p>To: All Participants<p/><p>From: Sakai Administrator - admin@weblearn.uk</p>TESTING :DDD
.
250 Ok
DEBUG SMTP: message successfully delivered to mail server
QUIT
221 Bye
16-Oct-2020 11:27:59.183 INFO [http-nio-8080-exec-1] org.sakaiproject.email.impl.BasicEmailService.sendToUsers sendToUsers: headers[ Content-Type: text/html; charset=utf-8 From: admin@weblearn.uk Subject: TESTING :DDD] to[  mm@mm.com mm2@mm.com]
`