### PR TITLE
WL-5365 Disable news and maillist.

### DIFF
--- a/docker/sakai/placeholder.properties
+++ b/docker/sakai/placeholder.properties
@@ -225,14 +225,15 @@ sakai.rutgers.linktool,\
 sakai.samigo,sakai.sections,sakai.feeds,blogger,sakai.presentation,\
 sakai.basiclti,sakai-site-manage-link-helper,\
 sakai.assignment2,sakai.delegatedaccess,sakai.podcasts,\
-sakai.gradebook.tool,sakai.postem
+sakai.gradebook.tool,sakai.postem,\
+sakai.mailbox,sakai.simple.rss,oxford-podcasts
 
 # Visible Tools:
 visibleTools@org.sakaiproject.tool.api.ActiveToolManager=\
 sakai.membership,sakai.usermembership,sakai.schedule,sakai.resources,\
 sakai.announcements,sakai.synoptic.announcement,sakai.sitesetup,\
-sakai.preferences,sakai.iframe,sakai.rwiki,sakai.news,\
-sakai.search,sakai.help,sakai.mneme,sakai.mailtool
+sakai.preferences,sakai.iframe,sakai.rwiki,\
+sakai.search,sakai.help,sakai.mneme
 
 # SAMIGO CONFIGURATION
 


### PR DESCRIPTION
As part of the shutdown of WebLearn we are preventing people from adding the less used tools. Podcasts is part of the newsfeed tool so that has gone too.