### PR TITLE
WL-5363 Increase Admin Site Permission Timeout

### DIFF
--- a/docker/sakai/placeholder.properties
+++ b/docker/sakai/placeholder.properties
@@ -951,3 +951,6 @@ assignments.block.resubmission.site.types=submission
 
 # Any of these site types don't allow visible date to be enabled.
 assignments.block.visible.site.types=submission
+
+# Increase the amount of time that changing permissions can take (3 days)
+site.adminperms.maxrun.secs=259200


### PR DESCRIPTION
To change the permissions across all the sites in WebLearn it takes a long time and we need to make several changes to support the decommisioning of WebLearn.