### PR TITLE
Drop the opencast repository

### DIFF
--- a/master/pom.xml
+++ b/master/pom.xml
@@ -276,17 +276,6 @@
         <updatePolicy>never</updatePolicy>
       </releases>
     </pluginRepository>
-    <pluginRepository>
-        <id>opencast</id>
-        <name>Opencast Repo</name>
-        <url>https://nexus.opencast.org/nexus/content/groups/public</url>
-        <snapshots>
-            <enabled>false</enabled>
-        </snapshots>
-        <releases>
-            <enabled>true</enabled>
-        </releases>
-    </pluginRepository>
   </pluginRepositories>
   <repositories>
    <repository>
@@ -336,17 +325,6 @@
         <enabled>true</enabled>
         <checksumPolicy>ignore</checksumPolicy>
       </snapshots>
-    </repository>
-    <repository>
-        <id>opencast</id>
-        <name>Opencast Repo</name>
-        <url>https://nexus.opencast.org/nexus/content/groups/public</url>
-        <snapshots>
-            <enabled>false</enabled>
-        </snapshots>
-        <releases>
-            <enabled>true</enabled>
-        </releases>
     </repository>
   </repositories>
 


### PR DESCRIPTION
The responsitory is no longer available and so breaks the build.